### PR TITLE
Amend contradictory DeleteFile comment in header

### DIFF
--- a/dokan/dokan.h
+++ b/dokan/dokan.h
@@ -174,9 +174,9 @@ typedef struct _DOKAN_OPERATIONS {
 	// you can delete the file or not, and return 0 (when you can delete it)
 	// or appropriate error codes such as -ERROR_DIR_NOT_EMPTY,
 	// -ERROR_SHARING_VIOLATION.
-	// When you return 0 (ERROR_SUCCESS), you get Cleanup with
-	// FileInfo->DeleteOnClose set TRUE and you have to delete the
-	// file in Close.
+	// When you return 0 (ERROR_SUCCESS), you get a Cleanup call with
+	// FileInfo->DeleteOnClose set to TRUE and you have to delete the
+	// file being closed.
 	int (DOKAN_CALLBACK *DeleteFile) (
 		LPCWSTR, // FileName
 		PDOKAN_FILE_INFO);


### PR DESCRIPTION
The same header says 'Delete on when "cleanup" is called' on the DokanFileInfo
definition, and "you must delete the file in Cleanup". Also, this contradicts
the mirror application behaviour, where the file/directory deletion is done on
Cleanup, not CloseFile.