### PR TITLE
Include windows.h in the main dokan header file

### DIFF
--- a/dokan/dokan.h
+++ b/dokan/dokan.h
@@ -22,6 +22,8 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 #ifndef _DOKAN_H_
 #define _DOKAN_H_
 
+#include <Windows.h>
+
 #define DOKAN_DRIVER_NAME	L"dokan.sys"
 
 #ifdef _EXPORTING


### PR DESCRIPTION
If someone forgets to #include windows.h before dokan.h is included, weird
errors appear. It is good practice for header files to be self-contained.