### PR TITLE
Exported function names for x86/x64 library

### DIFF
--- a/dokan/dokan.h
+++ b/dokan/dokan.h
@@ -27,7 +27,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 #define DOKAN_DRIVER_NAME	L"dokan.sys"
 
 #ifdef _EXPORTING
-  #define DOKANAPI __declspec(dllexport) __stdcall
+  #define DOKANAPI /*__declspec(dllexport)*/ __stdcall // exports defined in dokan.def
 #else
   #define DOKANAPI __declspec(dllimport) __stdcall
 #endif

--- a/dokan/dokan.vcxproj
+++ b/dokan/dokan.vcxproj
@@ -93,8 +93,7 @@
       <PreprocessorDefinitions>_WINDLL;_EXPORTING;%(PreprocessorDefinitions);</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <ModuleDefinitionFile>
-      </ModuleDefinitionFile>
+      <ModuleDefinitionFile>dokan.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -109,8 +108,7 @@
       <PreprocessorDefinitions>_WINDLL;_EXPORTING;%(PreprocessorDefinitions);</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <ModuleDefinitionFile>
-      </ModuleDefinitionFile>
+      <ModuleDefinitionFile>dokan.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -125,8 +123,7 @@
       <PreprocessorDefinitions>_WINDLL;_EXPORTING;%(PreprocessorDefinitions);</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <ModuleDefinitionFile>
-      </ModuleDefinitionFile>
+      <ModuleDefinitionFile>dokan.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -141,8 +138,7 @@
       <PreprocessorDefinitions>_WINDLL;_EXPORTING;%(PreprocessorDefinitions);</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <ModuleDefinitionFile>
-      </ModuleDefinitionFile>
+      <ModuleDefinitionFile>dokan.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -171,6 +167,9 @@
     <ClInclude Include="dokani.h" />
     <ClInclude Include="list.h" />
     <ClInclude Include="fileinfo.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="dokan.def" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/dokan_control/dokan_control.vcxproj
+++ b/dokan_control/dokan_control.vcxproj
@@ -99,7 +99,6 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);dokan.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>../debug</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -116,7 +115,6 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);dokan.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>../debug</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/dokan_fuse/src/fusemain.cpp
+++ b/dokan_fuse/src/fusemain.cpp
@@ -955,8 +955,8 @@ void impl_file_locks::remove_file(const std::string& name)
 	EnterCriticalSection(&lock);
 	file_locks_t::iterator i = file_locks.find(name);
 	if (i != file_locks.end() && !i->second->first) {
-		file_locks.erase(i);
 		delete i->second;
+		file_locks.erase(i);
 	}
 	LeaveCriticalSection(&lock);
 }

--- a/dokan_mirror/dokan_mirror.vcxproj
+++ b/dokan_mirror/dokan_mirror.vcxproj
@@ -99,7 +99,6 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>../debug</AdditionalLibraryDirectories>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);dokan.lib</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
     </Link>
   </ItemDefinitionGroup>
@@ -116,7 +115,6 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>../debug</AdditionalLibraryDirectories>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);dokan.lib</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Tried the current v0.7.3-beta release and could not bind to the library because of mangling/decorated function names in the x86 version of the library. Hope that my changes ( - works on my machine ;-) - ) correspond to the usual/common approach to handle this kind of problem.

Had to change the additional dependencies in the project files for control and mirror in order to build complete solution on my machine, is this only a problem on my site?