### PR TITLE
MoveFileEx fix

### DIFF
--- a/dokan/setfile.c
+++ b/dokan/setfile.c
@@ -247,7 +247,7 @@ DispatchSetInformation(
 	eventInfo = DispatchCommon(
 		EventContext, sizeOfEventInfo, DokanInstance, &fileInfo, &openInfo);
 	
-	DbgPrint("###SetFileInfo %04d\n", openInfo != NULL ? openInfo->EventId : -1);
+	DbgPrint("###SetFileInfo %04d  %d\n", openInfo != NULL ? openInfo->EventId : -1, EventContext->Operation.SetFile.FileInformationClass);
 
 	switch (EventContext->Operation.SetFile.FileInformationClass) {
 	case FileAllocationInformation:

--- a/dokan_fuse/src/docanfuse.cpp
+++ b/dokan_fuse/src/docanfuse.cpp
@@ -594,11 +594,23 @@ struct fuse_chan *fuse_mount(const char *mountpoint, struct fuse_args *args)
 
 void fuse_unmount(const char *mountpoint, struct fuse_chan *ch)
 {
-	if (ch==NULL || mountpoint==NULL || strlen(mountpoint)==0) return;
+	if (mountpoint==NULL || strlen(mountpoint)==0) return;
+
+	fuse_chan chan;
+	if (!ch) {
+		ch = &chan;
+		ch->init();
+		ch->mountpoint = mountpoint;
+	}
+
 	//Unmount attached FUSE filesystem
 	if (ch->ResolvedDokanRemoveMountPoint) {
 		wchar_t wmountpoint[MAX_PATH+1];
 		mbstowcs(wmountpoint,mountpoint,MAX_PATH);
+		wchar_t& last = wmountpoint[wcslen(wmountpoint) - 1];
+		if (last == L'\\'
+			|| last == L'/')
+			last = L'\0';
 		ch->ResolvedDokanRemoveMountPoint(wmountpoint);
 		return;
 	}

--- a/dokan_fuse/src/fusemain.cpp
+++ b/dokan_fuse/src/fusemain.cpp
@@ -181,8 +181,8 @@ int impl_fuse_context::do_create_file(LPCWSTR FileName, DWORD Disposition, DWORD
 
 int impl_fuse_context::convert_flags(DWORD Flags)
 {
-	bool read=(Flags & ACCESS_READ) == 1;
-	bool write=(Flags & ACCESS_WRITE) == 1;
+	bool read=(Flags & ACCESS_READ);
+	bool write=(Flags & ACCESS_WRITE);
 	if (read && !write)
 		return O_RDONLY;
 	if (!read && write)
@@ -955,7 +955,8 @@ void impl_file_locks::remove_file(const std::string& name)
 	EnterCriticalSection(&lock);
 	file_locks_t::iterator i = file_locks.find(name);
 	if (i != file_locks.end() && !i->second->first) {
-		delete i->second;
+		if (i->second)
+			delete i->second;
 		file_locks.erase(i);
 	}
 	LeaveCriticalSection(&lock);

--- a/dokan_fuse/src/fusemain.cpp
+++ b/dokan_fuse/src/fusemain.cpp
@@ -181,8 +181,8 @@ int impl_fuse_context::do_create_file(LPCWSTR FileName, DWORD Disposition, DWORD
 
 int impl_fuse_context::convert_flags(DWORD Flags)
 {
-	bool read=(Flags & ACCESS_READ);
-	bool write=(Flags & ACCESS_WRITE);
+	bool read=(Flags & ACCESS_READ) != 0;
+	bool write=(Flags & ACCESS_WRITE) != 0;
 	if (read && !write)
 		return O_RDONLY;
 	if (!read && write)


### PR DESCRIPTION
This is a fix for CreateFile with a SL_OPEN_TARGET_DIRECTORY flag, which should open the containing directory instead of the file itself.
This flag is used in the MoveFileEx WinAPI with the MOVEFILE_REPLACE_EXISTING flag, which opens the target file's containing directory before deleting the target file. Without the fix this API fails with "permission denied" because the target file is opened and cannot be deleted.
Now the git push command works via dokan!