### PR TITLE
Use _malloca() for debug strings to avoid buffer overflows

### DIFF
--- a/dokan/dokanc.h
+++ b/dokan/dokanc.h
@@ -23,6 +23,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 #define _DOKANC_H_
 
 #include "dokan.h"
+#include <malloc.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -77,30 +78,52 @@ static
 VOID
 DokanDbgPrint(LPCSTR format, ...)
 {
-	char buffer[512];
+	const char *outputString;
+	char *buffer;
+	size_t length;
 	va_list argp;
+
 	va_start(argp, format);
-    vsprintf_s(buffer, sizeof(buffer)/sizeof(char), format, argp);
-    va_end(argp);
+	length = _vscprintf(format, argp) + 1;
+	buffer = _malloca(length*sizeof(char));
+	if (buffer) {
+		vsprintf_s(buffer, length, format, argp);
+		outputString = buffer;
+	} else {
+		outputString = format;
+	}
 	if (g_UseStdErr)
-		fputs(buffer, stderr);
+		fputs(outputString, stderr);
 	else
-		OutputDebugStringA(buffer);
+		OutputDebugStringA(outputString);
+	_freea(buffer);
+	va_end(argp);
 }
 
 static
 VOID
 DokanDbgPrintW(LPCWSTR format, ...)
 {
-	WCHAR buffer[512];
+	const WCHAR *outputString;
+	WCHAR *buffer;
+	size_t length;
 	va_list argp;
+
 	va_start(argp, format);
-    vswprintf_s(buffer, sizeof(buffer)/sizeof(WCHAR), format, argp);
-    va_end(argp);
+	length = _vscwprintf(format, argp) + 1;
+	buffer = _malloca(length*sizeof(WCHAR));
+	if (buffer) {
+		vswprintf_s(buffer, length, format, argp);
+		outputString = buffer;
+	} else {
+		outputString = format;
+	}
 	if (g_UseStdErr)
-		fputws(buffer, stderr);
+		fputws(outputString, stderr);
 	else
-		OutputDebugStringW(buffer);
+		OutputDebugStringW(outputString);
+	_freea(buffer);
+	va_end(argp);
 }
 
 

--- a/dokan_np/dokannp.c
+++ b/dokan_np/dokannp.c
@@ -4,16 +4,28 @@
 #include <stdio.h>
 #include <npapi.h>
 #include <strsafe.h>
+#include <malloc.h>
 
 static VOID
 DokanDbgPrintW(LPCWSTR format, ...)
 {
-	WCHAR buffer[512];
+	const WCHAR *outputString;
+	WCHAR *buffer;
+	size_t length;
 	va_list argp;
+
 	va_start(argp, format);
-	StringCchVPrintfW(buffer, 127, format, argp);
-    va_end(argp);
-	OutputDebugStringW(buffer);
+	length = _vscwprintf(format, argp) + 1;
+	buffer = _malloca(length*sizeof(WCHAR));
+	if (buffer) {
+		StringCchVPrintfW(buffer, length, format, argp);
+		outputString = buffer;
+	} else {
+		outputString = format;
+	}
+	OutputDebugStringW(outputString);
+	_freea(buffer);
+	va_end(argp);
 }
 
 #define DbgPrintW(format, ...) \


### PR DESCRIPTION
While the sprintf_s functions are supposed to protect from buffer overflows and other errors, they still raise an exception if the buffer is too small, so any debug string longer than 512 characters still crashes the program. In practice, this limit is exceeded very easily, for example, when [matching a file name with a length of MAX_PATH against itself](https://github.com/dokan-dev/dokany/blob/master/dokan/directory.c#L382).

Instead of just increasing the buffer size and/or using snprintf, I prefer to use a combination of _vscwprintf() and _malloca()/_freea(), which computes the final length and then calls either alloca() for strings below 1024 bytes or malloc() for longer ones. This makes sure the string always gets shown in full (well, except for the unlikely case of a malloc() failure) and should eliminate this bug class without impacting performance too much.