### PR TITLE
use struct stat from cygwin as struct FUSE_STAT for better compatibility

### DIFF
--- a/dokan_fuse/include/fuse_win.h
+++ b/dokan_fuse/include/fuse_win.h
@@ -28,13 +28,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-int ntstatus_error_to_errno(int win_res);
-int errno_to_ntstatus_error(int err);
+	int ntstatus_error_to_errno(int win_res);
+	int errno_to_ntstatus_error(int err);
 
-//This stuff is useful only on Windows in MSVC
+	//This stuff is useful only on Windows in MSVC
 #ifdef _MSC_VER
-char** convert_args(int argc, wchar_t* argv[]);
-void free_converted_args(int argc, char **argv);
+	char** convert_args(int argc, wchar_t* argv[]);
+	void free_converted_args(int argc, char **argv);
 #endif
 
 #ifdef __cplusplus
@@ -101,13 +101,18 @@ struct flock {
 /////////////////////////////////////////////////////////////////////
 #if defined(_MSC_VER)
 //UNIX compatibility
+typedef struct timespec timestruc_t;
 typedef unsigned int mode_t;
+typedef unsigned short nlink_t;
 typedef unsigned int pid_t;
 typedef unsigned int gid_t;
 typedef unsigned int uid_t;
+typedef unsigned int blksize_t;
+typedef unsigned __int64 blkcnt_t;
 typedef unsigned int uint32_t;
 typedef unsigned __int64 uint64_t;
 typedef __int64 int64_t;
+
 
 //OCTAL constants!
 #define	S_IFLNK 0120000
@@ -154,7 +159,36 @@ struct flock {
 
 #else
 #define FUSE_OFF_T __int64
-#define FUSE_STAT _stati64
+// #define FUSE_STAT _stati64
+// use stat from cygwin instead for having more members and 
+// being more compatible
+// stat ported from cygwin sys/stat.h
+struct stat64_cygwin
+{
+	dev_t         st_dev;
+	uint64_t      st_ino;
+	mode_t        st_mode;
+	nlink_t       st_nlink;
+	uid_t         st_uid;
+	gid_t         st_gid;
+	dev_t         st_rdev;
+	FUSE_OFF_T    st_size;
+	timestruc_t   st_atim;
+	timestruc_t   st_mtim;
+	timestruc_t   st_ctim;
+	blksize_t     st_blksize;
+	blkcnt_t      st_blocks;
+	timestruc_t   st_birthtim;
+};
+/* The following breaks struct stat definiton in native Windows stats.h
+* So whenever referencing st_atime|st_ctime|st_mtime, replacing is needed.
+*/
+/*
+#define st_atime st_atim.tv_sec
+#define st_ctime st_ctim.tv_sec
+#define st_mtime st_mtim.tv_sec
+*/
+#define FUSE_STAT stat64_cygwin
 #if 0
 struct stat64 {
 	dev_t st_dev;

--- a/dokan_fuse/include/fuse_win.h
+++ b/dokan_fuse/include/fuse_win.h
@@ -28,13 +28,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-	int ntstatus_error_to_errno(int win_res);
-	int errno_to_ntstatus_error(int err);
+int ntstatus_error_to_errno(int win_res);
+int errno_to_ntstatus_error(int err);
 
-	//This stuff is useful only on Windows in MSVC
+//This stuff is useful only on Windows in MSVC
 #ifdef _MSC_VER
-	char** convert_args(int argc, wchar_t* argv[]);
-	void free_converted_args(int argc, char **argv);
+char** convert_args(int argc, wchar_t* argv[]);
+void free_converted_args(int argc, char **argv);
 #endif
 
 #ifdef __cplusplus

--- a/dokan_fuse/include/utils.h
+++ b/dokan_fuse/include/utils.h
@@ -40,12 +40,12 @@ template<class T> void convertStatlikeBuf(const struct FUSE_STAT *stbuf, const s
 	find_data->nFileSizeLow=(DWORD) stbuf->st_size;
 	find_data->nFileSizeHigh=stbuf->st_size>>32;
 #endif
-	if (stbuf->st_ctime!=0)
-		find_data->ftCreationTime=unixTimeToFiletime(stbuf->st_ctime);
-	if (stbuf->st_atime!=0)
-		find_data->ftLastAccessTime=unixTimeToFiletime(stbuf->st_atime);
-	if (stbuf->st_mtime!=0)
-		find_data->ftLastWriteTime=unixTimeToFiletime(stbuf->st_mtime);
+	if (stbuf->st_ctim.tv_sec!=0)
+		find_data->ftCreationTime=unixTimeToFiletime(stbuf->st_ctim.tv_sec);
+	if (stbuf->st_atim.tv_sec!=0)
+		find_data->ftLastAccessTime=unixTimeToFiletime(stbuf->st_atim.tv_sec);
+	if (stbuf->st_mtim.tv_sec!=0)
+		find_data->ftLastWriteTime=unixTimeToFiletime(stbuf->st_mtim.tv_sec);
 
 	//TODO: add support for read-only files - try to derive it from file's owner?
 	std::string fname=extract_file_name(name);

--- a/dokan_fuse/src/fusemain.cpp
+++ b/dokan_fuse/src/fusemain.cpp
@@ -794,18 +794,18 @@ int impl_fuse_context::set_file_time(PCWSTR file_name, const FILETIME* creation_
 		struct timespec tv[2]={0};
 		//TODO: support nanosecond resolution
 		//Access time
-		CHECKED(helper_set_time_struct(last_access_time,st.st_atime,&(tv[0].tv_sec)));		
+		CHECKED(helper_set_time_struct(last_access_time,st.st_atim.tv_sec,&(tv[0].tv_sec)));		
 		//Modification time
-		CHECKED(helper_set_time_struct(last_write_time,st.st_mtime,&(tv[1].tv_sec)));
+		CHECKED(helper_set_time_struct(last_write_time,st.st_mtim.tv_sec,&(tv[1].tv_sec)));
 
 		return ops_.utimens(fname.c_str(),tv);
 	} else
 	{
 		struct utimbuf ut={0};
 		//Access time
-		CHECKED(helper_set_time_struct(last_access_time,st.st_atime,&(ut.actime)));
+		CHECKED(helper_set_time_struct(last_access_time,st.st_atim.tv_sec,&(ut.actime)));
 		//Modification time
-		CHECKED(helper_set_time_struct(last_write_time,st.st_mtime,&(ut.modtime)));
+		CHECKED(helper_set_time_struct(last_write_time,st.st_mtim.tv_sec,&(ut.modtime)));
 		
 		return ops_.utime(fname.c_str(),&ut);
 	}


### PR DESCRIPTION
The original struct stat lacks members like st_blksize etc and uses atime/mtime/ctime, which can only have accuracy in seconds. What's more, the difference with the struct FUSE_STAT in DokanFUSE and struct stat in user program causes stack overflows. The new struct FUSE_STAT is ported from msys2 64bits, which is actually ported from cygwin 64bits. With this modification, users with msys/cygwin(64-bit)toolchains can compile their FUSE programs with DokanFUSE library directly without any more modification other than changing their header files. However, for other toolchains like MSVC,mingw and cygwin 32bits, you need to explicitly replace struct stat in your FUSE program to use struct FUSE_STAT from fuse_win.h. Because the implementation of stat.h varies from operating systems and toolchains, it's hard to find a simply way to be compatible with all of them. 