### PR TITLE
VPB read only members should not be changed

### DIFF
--- a/sys/fscontrol.c
+++ b/sys/fscontrol.c
@@ -325,11 +325,8 @@ VOID DokanInitVpb(__in PVPB Vpb, __in PDEVICE_OBJECT DiskDevice,
                   __in PDEVICE_OBJECT VolumeDevice) {
   if (Vpb != NULL) {
     Vpb->DeviceObject = VolumeDevice;
-    Vpb->RealDevice = DiskDevice;
-    Vpb->Flags |= VPB_MOUNTED;
     Vpb->VolumeLabelLength = (USHORT)wcslen(VOLUME_LABEL) * sizeof(WCHAR);
-    RtlStringCchCopyW(Vpb->VolumeLabel,
-                      sizeof(Vpb->VolumeLabel) / sizeof(WCHAR), VOLUME_LABEL);
+    RtlStringCbCopyW(Vpb->VolumeLabel, Vpb->VolumeLabel, VOLUME_LABEL);
     Vpb->SerialNumber = 0x19831116;
   }
 }

--- a/sys/fscontrol.c
+++ b/sys/fscontrol.c
@@ -325,8 +325,8 @@ VOID DokanInitVpb(__in PVPB Vpb, __in PDEVICE_OBJECT DiskDevice,
                   __in PDEVICE_OBJECT VolumeDevice) {
   if (Vpb != NULL) {
     Vpb->DeviceObject = VolumeDevice;
-    Vpb->VolumeLabelLength = (USHORT)wcslen(VOLUME_LABEL) * sizeof(WCHAR);
-    RtlStringCbCopyW(Vpb->VolumeLabel, Vpb->VolumeLabel, VOLUME_LABEL);
+    Vpb->VolumeLabelLength = sizeof(VOLUME_LABEL) - sizeof(WCHAR);
+    RtlStringCbCopyW(Vpb->VolumeLabel, Vpb->VolumeLabelLength, VOLUME_LABEL);
     Vpb->SerialNumber = 0x19831116;
   }
 }


### PR DESCRIPTION
The RealDevice and Flags members are read only members of the VPB structure (https://msdn.microsoft.com/en-us/library/windows/hardware/ff625892%28v=vs.85%29.aspx).
VPB_MOUNTED is set by the I/O manager immediately after IRP_MN_MOUNT_VOLUME is completed with a successful status.
RealDevice should point to the disk device already as this point.