### PR TITLE
Support STATUS_NOT_IMPLEMENTED as a possible result from callbacks

### DIFF
--- a/dokan/flush.c
+++ b/dokan/flush.c
@@ -28,6 +28,7 @@ VOID DispatchFlush(HANDLE Handle, PEVENT_CONTEXT EventContext,
   PEVENT_INFORMATION eventInfo;
   ULONG sizeOfEventInfo = sizeof(EVENT_INFORMATION);
   PDOKAN_OPEN_INFO openInfo;
+  NTSTATUS status;
 
   CheckFileName(EventContext->Operation.Flush.FileName);
 
@@ -36,13 +37,18 @@ VOID DispatchFlush(HANDLE Handle, PEVENT_CONTEXT EventContext,
 
   DbgPrint("###Flush %04d\n", openInfo != NULL ? openInfo->EventId : -1);
 
-  eventInfo->Status = STATUS_SUCCESS;
-
   if (DokanInstance->DokanOperations->FlushFileBuffers) {
 
-    NTSTATUS status = DokanInstance->DokanOperations->FlushFileBuffers(
+    status = DokanInstance->DokanOperations->FlushFileBuffers(
         EventContext->Operation.Flush.FileName, &fileInfo);
 
+  } else {
+    status = STATUS_NOT_IMPLEMENTED;
+  }
+
+  if (status == STATUS_NOT_IMPLEMENTED) {
+    eventInfo->Status = STATUS_SUCCESS;
+  } else {
     eventInfo->Status =
         status != STATUS_SUCCESS ? STATUS_NOT_SUPPORTED : STATUS_SUCCESS;
   }

--- a/dokan/lock.c
+++ b/dokan/lock.c
@@ -50,8 +50,10 @@ VOID DispatchLock(HANDLE Handle, PEVENT_CONTEXT EventContext,
           // EventContext->Operation.Lock.Key,
           &fileInfo);
 
-      eventInfo->Status =
-          status != STATUS_SUCCESS ? STATUS_LOCK_NOT_GRANTED : STATUS_SUCCESS;
+      if (status != STATUS_NOT_IMPLEMENTED) {
+        eventInfo->Status =
+            status != STATUS_SUCCESS ? STATUS_LOCK_NOT_GRANTED : STATUS_SUCCESS;
+      }
     }
     break;
   case IRP_MN_UNLOCK_ALL:
@@ -68,7 +70,9 @@ VOID DispatchLock(HANDLE Handle, PEVENT_CONTEXT EventContext,
           // EventContext->Operation.Lock.Key,
           &fileInfo);
 
-      eventInfo->Status = STATUS_SUCCESS; // always succeeds so it cannot fail ?
+      if (status != STATUS_NOT_IMPLEMENTED) {
+        eventInfo->Status = STATUS_SUCCESS; // always succeeds so it cannot fail ?
+      }
     }
     break;
   default:

--- a/dokan/security.c
+++ b/dokan/security.c
@@ -90,7 +90,7 @@ VOID DispatchSetSecurity(HANDLE Handle, PEVENT_CONTEXT EventContext,
         &fileInfo);
   }
 
-  if (status > 0) {
+  if (status != STATUS_SUCCESS) {
     eventInfo->Status = STATUS_INVALID_PARAMETER;
     eventInfo->BufferLength = 0;
   } else {

--- a/dokan/setfile.c
+++ b/dokan/setfile.c
@@ -43,12 +43,19 @@ DokanSetAllocationInformation(PEVENT_CONTEXT EventContext,
   // is less than the end-of-file position, the end-of-file position is
   // automatically
   // adjusted to match the allocation size.
+  NTSTATUS status;
 
   if (DokanOperations->SetAllocationSize) {
-    return DokanOperations->SetAllocationSize(
+    status = DokanOperations->SetAllocationSize(
         EventContext->Operation.SetFile.FileName,
         allocInfo->AllocationSize.QuadPart, FileInfo);
+  } else {
+    status = STATUS_NOT_IMPLEMENTED;
   }
+
+  if( status != STATUS_NOT_IMPLEMENTED )
+    return status;
+
   // How can we check the current end-of-file position?
   if (allocInfo->AllocationSize.QuadPart == 0) {
     return DokanOperations->SetEndOfFile(
@@ -81,7 +88,7 @@ DokanSetBasicInformation(PEVENT_CONTEXT EventContext, PDOKAN_FILE_INFO FileInfo,
       EventContext->Operation.SetFile.FileName, basicInfo->FileAttributes,
       FileInfo);
 
-  if (status > 0)
+  if (status != STATUS_SUCCESS)
     return status;
 
   creation.dwLowDateTime = basicInfo->CreationTime.LowPart;

--- a/dokan/setfile.c
+++ b/dokan/setfile.c
@@ -53,20 +53,7 @@ DokanSetAllocationInformation(PEVENT_CONTEXT EventContext,
     status = STATUS_NOT_IMPLEMENTED;
   }
 
-  if( status != STATUS_NOT_IMPLEMENTED )
-    return status;
-
-  // How can we check the current end-of-file position?
-  if (allocInfo->AllocationSize.QuadPart == 0) {
-    return DokanOperations->SetEndOfFile(
-        EventContext->Operation.SetFile.FileName,
-        allocInfo->AllocationSize.QuadPart, FileInfo);
-  } else {
-    DbgPrint("  SetAllocationInformation %I64d, can't handle this parameter.\n",
-             allocInfo->AllocationSize.QuadPart);
-  }
-
-  return STATUS_SUCCESS;
+  return status;
 }
 
 NTSTATUS

--- a/dokan/volume.c
+++ b/dokan/volume.c
@@ -69,11 +69,6 @@ DokanFsVolumeInformation(PEVENT_INFORMATION EventInfo,
   PFILE_FS_VOLUME_INFORMATION volumeInfo =
       (PFILE_FS_VOLUME_INFORMATION)EventInfo->Buffer;
 
-  if (!DokanOperations->GetVolumeInformation) {
-    // return STATUS_NOT_IMPLEMENTED;
-    DokanOperations->GetVolumeInformation = DokanGetVolumeInformation;
-  }
-
   remainingLength = EventContext->Operation.Volume.BufferLength;
 
   if (remainingLength < sizeof(FILE_FS_VOLUME_INFORMATION)) {
@@ -83,15 +78,29 @@ DokanFsVolumeInformation(PEVENT_INFORMATION EventInfo,
   RtlZeroMemory(volumeName, sizeof(volumeName));
   RtlZeroMemory(fsName, sizeof(fsName));
 
-  status = DokanOperations->GetVolumeInformation(
-      volumeName,                         // VolumeNameBuffer
-      sizeof(volumeName) / sizeof(WCHAR), // VolumeNameSize
-      &volumeSerial,                      // VolumeSerialNumber
-      &maxComLength,                      // MaximumComponentLength
-      &fsFlags,                           // FileSystemFlags
-      fsName,                             // FileSystemNameBuffer
-      sizeof(fsName) / sizeof(WCHAR),     // FileSystemNameSize
-      FileInfo);
+  if (DokanOperations->GetVolumeInformation) {
+    status = DokanOperations->GetVolumeInformation(
+        volumeName,                         // VolumeNameBuffer
+        sizeof(volumeName) / sizeof(WCHAR), // VolumeNameSize
+        &volumeSerial,                      // VolumeSerialNumber
+        &maxComLength,                      // MaximumComponentLength
+        &fsFlags,                           // FileSystemFlags
+        fsName,                             // FileSystemNameBuffer
+        sizeof(fsName) / sizeof(WCHAR),     // FileSystemNameSize
+        FileInfo);
+  }
+
+  if( status == STATUS_NOT_IMPLEMENTED ) {
+    status = DokanGetVolumeInformation(
+        volumeName,                         // VolumeNameBuffer
+        sizeof(volumeName) / sizeof(WCHAR), // VolumeNameSize
+        &volumeSerial,                      // VolumeSerialNumber
+        &maxComLength,                      // MaximumComponentLength
+        &fsFlags,                           // FileSystemFlags
+        fsName,                             // FileSystemNameBuffer
+        sizeof(fsName) / sizeof(WCHAR),     // FileSystemNameSize
+        FileInfo);
+  }
 
   if (status != STATUS_SUCCESS) {
     return status;
@@ -130,21 +139,26 @@ DokanFsSizeInformation(PEVENT_INFORMATION EventInfo,
   PFILE_FS_SIZE_INFORMATION sizeInfo =
       (PFILE_FS_SIZE_INFORMATION)EventInfo->Buffer;
 
-  if (!DokanOperations->GetDiskFreeSpace) {
-    // return STATUS_NOT_IMPLEMENTED;
-    DokanOperations->GetDiskFreeSpace = DokanGetDiskFreeSpace;
-  }
-
   if (EventContext->Operation.Volume.BufferLength <
       sizeof(FILE_FS_SIZE_INFORMATION)) {
     return STATUS_BUFFER_OVERFLOW;
   }
 
-  status = DokanOperations->GetDiskFreeSpace(
-      &freeBytesAvailable, // FreeBytesAvailable
-      &totalBytes,         // TotalNumberOfBytes
-      &freeBytes,          // TotalNumberOfFreeBytes
-      FileInfo);
+  if (DokanOperations->GetDiskFreeSpace) {
+    status = DokanOperations->GetDiskFreeSpace(
+        &freeBytesAvailable, // FreeBytesAvailable
+        &totalBytes,         // TotalNumberOfBytes
+        &freeBytes,          // TotalNumberOfFreeBytes
+        FileInfo);
+  }
+
+  if (status == STATUS_NOT_IMPLEMENTED) {
+    status = DokanGetDiskFreeSpace(
+        &freeBytesAvailable, // FreeBytesAvailable
+        &totalBytes,         // TotalNumberOfBytes
+        &freeBytes,          // TotalNumberOfFreeBytes
+        FileInfo);
+  }
 
   if (status != STATUS_SUCCESS) {
     return status;
@@ -180,11 +194,6 @@ DokanFsAttributeInformation(PEVENT_INFORMATION EventInfo,
   PFILE_FS_ATTRIBUTE_INFORMATION attrInfo =
       (PFILE_FS_ATTRIBUTE_INFORMATION)EventInfo->Buffer;
 
-  if (!DokanOperations->GetVolumeInformation) {
-    DokanOperations->GetVolumeInformation = DokanGetVolumeInformation;
-    // return STATUS_NOT_IMPLEMENTED;
-  }
-
   remainingLength = EventContext->Operation.Volume.BufferLength;
 
   if (remainingLength < sizeof(FILE_FS_ATTRIBUTE_INFORMATION)) {
@@ -194,15 +203,29 @@ DokanFsAttributeInformation(PEVENT_INFORMATION EventInfo,
   RtlZeroMemory(volumeName, sizeof(volumeName));
   RtlZeroMemory(fsName, sizeof(fsName));
 
-  status = DokanOperations->GetVolumeInformation(
-      volumeName,                         // VolumeNameBuffer
-      sizeof(volumeName) / sizeof(WCHAR), // VolumeNameSize
-      &volumeSerial,                      // VolumeSerialNumber
-      &maxComLength,                      // MaximumComponentLength
-      &fsFlags,                           // FileSystemFlags
-      fsName,                             // FileSystemNameBuffer
-      sizeof(fsName) / sizeof(WCHAR),     // FileSystemNameSize
-      FileInfo);
+  if (DokanOperations->GetVolumeInformation) {
+    status = DokanOperations->GetVolumeInformation(
+        volumeName,                         // VolumeNameBuffer
+        sizeof(volumeName) / sizeof(WCHAR), // VolumeNameSize
+        &volumeSerial,                      // VolumeSerialNumber
+        &maxComLength,                      // MaximumComponentLength
+        &fsFlags,                           // FileSystemFlags
+        fsName,                             // FileSystemNameBuffer
+        sizeof(fsName) / sizeof(WCHAR),     // FileSystemNameSize
+        FileInfo);
+  }
+
+  if( status == STATUS_NOT_IMPLEMENTED ) {
+    status = DokanGetVolumeInformation(
+        volumeName,                         // VolumeNameBuffer
+        sizeof(volumeName) / sizeof(WCHAR), // VolumeNameSize
+        &volumeSerial,                      // VolumeSerialNumber
+        &maxComLength,                      // MaximumComponentLength
+        &fsFlags,                           // FileSystemFlags
+        fsName,                             // FileSystemNameBuffer
+        sizeof(fsName) / sizeof(WCHAR),     // FileSystemNameSize
+        FileInfo);
+  }
 
   if (status != STATUS_SUCCESS) {
     return status;
@@ -242,21 +265,26 @@ DokanFsFullSizeInformation(PEVENT_INFORMATION EventInfo,
   PFILE_FS_FULL_SIZE_INFORMATION sizeInfo =
       (PFILE_FS_FULL_SIZE_INFORMATION)EventInfo->Buffer;
 
-  if (!DokanOperations->GetDiskFreeSpace) {
-    DokanOperations->GetDiskFreeSpace = DokanGetDiskFreeSpace;
-    // return STATUS_NOT_IMPLEMENTED;
-  }
-
   if (EventContext->Operation.Volume.BufferLength <
       sizeof(FILE_FS_FULL_SIZE_INFORMATION)) {
     return STATUS_BUFFER_OVERFLOW;
   }
 
-  status = DokanOperations->GetDiskFreeSpace(
-      &freeBytesAvailable, // FreeBytesAvailable
-      &totalBytes,         // TotalNumberOfBytes
-      &freeBytes,          // TotalNumberOfFreeBytes
-      FileInfo);
+  if (DokanOperations->GetDiskFreeSpace) {
+    status = DokanOperations->GetDiskFreeSpace(
+        &freeBytesAvailable, // FreeBytesAvailable
+        &totalBytes,         // TotalNumberOfBytes
+        &freeBytes,          // TotalNumberOfFreeBytes
+        FileInfo);
+  }
+
+  if (status == STATUS_NOT_IMPLEMENTED) {
+    status = DokanGetDiskFreeSpace(
+        &freeBytesAvailable, // FreeBytesAvailable
+        &totalBytes,         // TotalNumberOfBytes
+        &freeBytes,          // TotalNumberOfFreeBytes
+        FileInfo);
+  }
 
   if (status != STATUS_SUCCESS) {
     return status;

--- a/dokan/write.c
+++ b/dokan/write.c
@@ -52,7 +52,7 @@ VOID DispatchWrite(HANDLE Handle, PEVENT_CONTEXT EventContext,
   PEVENT_INFORMATION eventInfo;
   PDOKAN_OPEN_INFO openInfo;
   ULONG writtenLength = 0;
-  int status;
+  NTSTATUS status;
   DOKAN_FILE_INFO fileInfo;
   BOOL bufferAllocated = FALSE;
   ULONG sizeOfEventInfo = sizeof(EVENT_INFORMATION);


### PR DESCRIPTION
Addition to my previous PR. Handle STATUS_NOT_IMPLEMENTED exactly same as if the callback was not set in DokanOperations. Most of callbacks already can safely return it, this is intended to support for the rest.