### PR TITLE
support hibernation mode

### DIFF
--- a/sys/timeout.c
+++ b/sys/timeout.c
@@ -260,6 +260,9 @@ Routine Description:
   LARGE_INTEGER timeout = {0};
   BOOLEAN waitObj = TRUE;
 
+  LARGE_INTEGER LastTime = { 0 };
+  LARGE_INTEGER CurrentTime = { 0 };
+
   DDbgPrint("==> DokanTimeoutThread\n");
 
   KeInitializeTimerEx(&timer, SynchronizationTimer);
@@ -268,6 +271,8 @@ Routine Description:
   pollevents[1] = (PVOID)&timer;
 
   KeSetTimerEx(&timer, timeout, DOKAN_CHECK_INTERVAL, NULL);
+
+  KeQuerySystemTime(&LastTime);
 
   while (waitObj) {
     status = KeWaitForMultipleObjects(2, pollevents, WaitAny, Executive,
@@ -278,8 +283,19 @@ Routine Description:
       // KillEvent or something error is occured
       waitObj = FALSE;
     } else {
-      ReleaseTimeoutPendingIrp(Dcb);
-      DokanCheckKeepAlive(Dcb);
+		// in this case the timer was executed and we are checking if the timer occured
+		// regulary using the period DOKAN_CHECK_INTERVAL. If not, this means the system
+		// was in sleep mode. If in this case the timer is faster awaken than the incoming IOCTL_KEEPALIVE
+		// the MountPoint would be removed by mistake (DokanCheckKeepAlive).
+		KeQuerySystemTime(&CurrentTime);
+		if ((CurrentTime.QuadPart - LastTime.QuadPart) > ((DOKAN_CHECK_INTERVAL + 2000) * 10000)) {
+			DDbgPrint("  System seems to be awaken from sleep mode. So do not Check Keep Alive yet.\n");
+		}
+		else {
+			ReleaseTimeoutPendingIrp(Dcb);
+			DokanCheckKeepAlive(Dcb);
+		}
+		KeQuerySystemTime(&LastTime);
     }
   }
 


### PR DESCRIPTION
If system goes into hibernation mode it can happen that DokanCheckKeepAlive remove the MountPoint by mistake.