### PR TITLE
fix mounting issue

### DIFF
--- a/sys/create.c
+++ b/sys/create.c
@@ -880,10 +880,7 @@ VOID DokanCompleteCreate(__in PIRP_ENTRY IrpEntry,
     DokanFreeFCB(fcb);
   }
 
-  irp->IoStatus.Status = status;
-  irp->IoStatus.Information = info;
-  IoCompleteRequest(irp, IO_NO_INCREMENT);
+  DokanCompleteIrpRequest(irp, status, info);
 
-  DokanPrintNTStatus(status);
   DDbgPrint("<== DokanCompleteCreate\n");
 }

--- a/sys/init.c
+++ b/sys/init.c
@@ -522,9 +522,9 @@ DokanCreateGlobalDiskDevice(__in PDRIVER_OBJECT DriverObject,
   // Establish user-buffer access method.
   //
   fsDiskDeviceObject->Flags |= DO_DIRECT_IO;
-  // fsDiskDeviceObject->Flags |= DO_LOW_PRIORITY_FILESYSTEM;
+  fsDiskDeviceObject->Flags |= DO_LOW_PRIORITY_FILESYSTEM;
   fsCdDeviceObject->Flags |= DO_DIRECT_IO;
-  // fsCdDeviceObject->Flags |= DO_LOW_PRIORITY_FILESYSTEM;
+  fsCdDeviceObject->Flags |= DO_LOW_PRIORITY_FILESYSTEM;
 
   fsDiskDeviceObject->Flags &= ~DO_DEVICE_INITIALIZING;
   fsCdDeviceObject->Flags &= ~DO_DEVICE_INITIALIZING;

--- a/sys/sys.vcxproj.filters
+++ b/sys/sys.vcxproj.filters
@@ -80,7 +80,7 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="dispatch.c">
-	  <Filter>Source Files</Filter>
+      <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="pnp.c">
       <Filter>Source Files</Filter>


### PR DESCRIPTION
If on the system fastfat and NTFS have higher priority than dokan, the mount of dokan can fail. This is fixed using this pull request. To reproduce the issue, just add a second harddrive with FAT format to the virtual server and reboot the machine. Then run mirror sample.

Here the whole process, so that you have all the background information:

1. Dokan registers the file system (DriverEntry)
2. Dokan makes access to the disk device (EVENT_START)
3. VPB is null and type is FILE_SYSTEM_DISK so Os needs to mount it
4. Operating system goes through all registered filesystems and those try to mount the volume
5. Some of file system are not loaded yet. So now the file system recognizer come into the play. The registered recognizers try to recognize the harddisk. This happens in most cases by reading the boot sector. If the disk is recognized, the file system is loaded. But if the read of the boot sector fails the whole chain is broken and the volume is not mounted (in our case this happened). In some case it can also cause never ending loops.
6. The last used filesystem is RAW

Somewhere in the file system list above is our registered file system it it can mount successfully our volume :smile: 

This is not related to the redirector issue, which I'm going to analyze as next.