### PR TITLE
Fix:Saving fileinfo after file creation in fuse.

### DIFF
--- a/dokan_fuse/src/fusemain.cpp
+++ b/dokan_fuse/src/fusemain.cpp
@@ -218,6 +218,7 @@ int impl_fuse_context::do_create_file(LPCWSTR FileName, DWORD Disposition,
 
   CHECKED(ops_.create(fname.c_str(), filemask_, &finfo));
 
+  file->set_finfo(finfo);
   DokanFileInfo->Context = reinterpret_cast<ULONG64>(file.release());
   return 0;
 }


### PR DESCRIPTION
The value of `fuse_file_info::fh` was `(uint64_t)(-1)`(<-- default value) after `fuse_create`.