### PR TITLE
use struct constructor in fuse example

### DIFF
--- a/samples/fuse_mirror/fusexmp.c
+++ b/samples/fuse_mirror/fusexmp.c
@@ -382,43 +382,45 @@ static int xmp_removexattr(const char *path, const char *name)
 }
 #endif /* HAVE_SETXATTR */
 
-static struct fuse_operations xmp_oper = {
-	.getattr	= xmp_getattr,
-	.access		= xmp_access,
-	.readlink	= xmp_readlink,
-	.readdir	= xmp_readdir,
-	.mknod		= xmp_mknod,
-	.mkdir		= xmp_mkdir,
-	.symlink	= xmp_symlink,
-	.unlink		= xmp_unlink,
-	.rmdir		= xmp_rmdir,
-	.rename		= xmp_rename,
-	.link		= xmp_link,
-	.chmod		= xmp_chmod,
-	.chown		= xmp_chown,
-	.truncate	= xmp_truncate,
+static struct xmp_oper : fuse_operations {
+	xmp_oper() {
+		getattr = xmp_getattr;
+		access = xmp_access;
+		readlink = xmp_readlink;
+		readdir = xmp_readdir;
+		mknod = xmp_mknod;
+		mkdir = xmp_mkdir;
+		symlink = xmp_symlink;
+		unlink = xmp_unlink;
+		rmdir = xmp_rmdir;
+		rename = xmp_rename;
+		link = xmp_link;
+		chmod = xmp_chmod;
+		chown = xmp_chown;
+		truncate = xmp_truncate;
 #ifdef HAVE_UTIMENSAT
-	.utimens	= xmp_utimens,
+		utimens = xmp_utimens;
 #endif
-	.open		= xmp_open,
-	.read		= xmp_read,
-	.write		= xmp_write,
-	.statfs		= xmp_statfs,
-	.release	= xmp_release,
-	.fsync		= xmp_fsync,
+		open = xmp_open;
+		read = xmp_read;
+		write = xmp_write;
+		statfs = xmp_statfs;
+		release = xmp_release;
+		fsync = xmp_fsync;
 #ifdef HAVE_POSIX_FALLOCATE
-	.fallocate	= xmp_fallocate,
+		fallocate = xmp_fallocate;
 #endif
 #ifdef HAVE_SETXATTR
-	.setxattr	= xmp_setxattr,
-	.getxattr	= xmp_getxattr,
-	.listxattr	= xmp_listxattr,
-	.removexattr	= xmp_removexattr,
+		setxattr = xmp_setxattr;
+		getxattr = xmp_getxattr;
+		listxattr = xmp_listxattr;
+		removexattr = xmp_removexattr;
 #endif
-};
+	}
+} operations;
 
 int main(int argc, char *argv[])
 {
 	umask(0);
-	return fuse_main(argc, argv, &xmp_oper, NULL);
+	return fuse_main(argc, argv, &operations, NULL);
 }


### PR DESCRIPTION
When fusexmp.c is compiled using msys2 toolchain, it would prompt "sorry, unimplemented: non-trivial designated initializers not supported". By using struct constructor, fusexmp.c can be compiled in both msys2 and cygwin.