### PR TITLE
use _WIN32 in FUSE wrapper headers instead of WIN32

### DIFF
--- a/dokan_fuse/include/fuse.h
+++ b/dokan_fuse/include/fuse.h
@@ -10,7 +10,7 @@
 #define _FUSE_H_
 
 /* Include Windows compatibility stuff early*/
-#ifdef WIN32
+#ifdef _WIN32
 #include "fuse_win.h"
 typedef struct _FILETIME FILETIME;
 #else
@@ -445,7 +445,7 @@ struct fuse_operations {
 	 */
 	int (*bmap) (const char *, size_t blocksize, uint64_t *idx);
 
-#ifdef WIN32
+#ifdef _WIN32
 	/* these to support extented windows calls */
 	uint32_t (*win_get_attributes) (const char *fn);
 	int (*win_set_attributes) (const char *fn, uint32_t attr);

--- a/dokan_fuse/include/fuse_common.h
+++ b/dokan_fuse/include/fuse_common.h
@@ -31,7 +31,7 @@
 
 /* This interface uses 64 bit off_t, except on Windows where it's 
 possible to use 32-bit filelengths for compatibility with MSVC CRT */
-#ifndef WIN32
+#ifndef _WIN32
 /* This interface uses 64 bit off_t */
 #if _FILE_OFFSET_BITS != 64
 #error Please add -D_FILE_OFFSET_BITS=64 to your compile flags!


### PR DESCRIPTION
We should use _WIN32 instead WIN32 in FUSE wrapper headers. _WIN32 is safer. 
And more importantly when using these wrapper headers to develop applications, WIN32 is not defined in` fuse.h#L13 `when in x64 platform. `fuse_win.h` needs to be included for later(`fuse.h#L448`) WIN32 being defined.