### PR TITLE
dokan: null-terminate string in unmount

### DIFF
--- a/dokan/mount.c
+++ b/dokan/mount.c
@@ -510,8 +510,9 @@ BOOL DOKANAPI DokanRemoveMountPoint(LPCWSTR MountPoint) {
       if (SendGlobalReleaseIRP(mountPoint)) {
         if (!IsMountPointDriveLetter(MountPoint)) {
           length = wcslen(mountPoint);
-          if (length < MAX_PATH) {
+          if (length+1 < MAX_PATH) {
             mountPoint[length] = L'\\';
+            mountPoint[length+1] = L'\0';
             // Required to remove reparse point (could also be done through
             // FSCTL_DELETE_REPARSE_POINT with DeleteMountPoint function)
             DeleteVolumeMountPoint(mountPoint);


### PR DESCRIPTION
Spotted this bug while hunting other issues.

This may have caused invalid input to DeleteVolumeMountPoint in the !IsMountPointDriveLetter case.