### PR TITLE
Call statfs with root directory /

### DIFF
--- a/dokan_fuse/src/fusemain.cpp
+++ b/dokan_fuse/src/fusemain.cpp
@@ -874,8 +874,7 @@ int impl_fuse_context::get_disk_free_space(PULONGLONG free_bytes_available,
   }
 
   struct statvfs vfs = {0};
-  // Why do we need path argument??
-  CHECKED(ops_.statfs("", &vfs));
+  CHECKED(ops_.statfs("/", &vfs));
 
   if (free_bytes_available != NULL)
     *free_bytes_available = uint64_t(vfs.f_bsize) * vfs.f_bavail;


### PR DESCRIPTION
Instead of calling statfs with an empty string we now call statfs with
the root directory "/". This is in line with POSIX which requires the
path to be valid and existing (an empty path is not)

I removed the comment `// Why do we need path argument??`. The answer to the question is that, on a Unix system, the path is needed to determine which filesystem you want to get the information from, i.e. depending on where the path resides, you would get the information about the filesystem the file/dir is located on.

http://linux.die.net/man/2/statfs