### PR TITLE
dokan_fuse: Use %ls for wide-character debug-print

### DIFF
--- a/dokan_fuse/src/dokanfuse.cpp
+++ b/dokan_fuse/src/dokanfuse.cpp
@@ -40,7 +40,7 @@ FuseFindFiles(LPCWSTR FileName,
               PDOKAN_FILE_INFO DokanFileInfo) {
   impl_fuse_context *impl = the_impl;
   if (impl->debug())
-    FWPRINTF(stderr, L"FindFiles :%s\n", FileName);
+    FWPRINTF(stderr, L"FindFiles :%ls\n", FileName);
 
   impl_chain_guard guard(impl, DokanFileInfo->ProcessId);
   return errno_to_ntstatus_error(
@@ -51,7 +51,7 @@ static void DOKAN_CALLBACK FuseCleanup(LPCWSTR FileName,
                                        PDOKAN_FILE_INFO DokanFileInfo) {
   impl_fuse_context *impl = the_impl;
   if (impl->debug())
-    FWPRINTF(stderr, L"Cleanup: %s\n\n", FileName);
+    FWPRINTF(stderr, L"Cleanup: %ls\n\n", FileName);
 
   impl_chain_guard guard(impl, DokanFileInfo->ProcessId);
   impl->cleanup(FileName, DokanFileInfo);
@@ -61,7 +61,7 @@ static NTSTATUS DOKAN_CALLBACK
 FuseDeleteDirectory(LPCWSTR FileName, PDOKAN_FILE_INFO DokanFileInfo) {
   impl_fuse_context *impl = the_impl;
   if (impl->debug())
-    FWPRINTF(stderr, L"DeleteDirectory %s\n", FileName);
+    FWPRINTF(stderr, L"DeleteDirectory %ls\n", FileName);
 
   impl_chain_guard guard(impl, DokanFileInfo->ProcessId);
   return errno_to_ntstatus_error(
@@ -173,7 +173,7 @@ FuseCreateFile(LPCWSTR FileName, PDOKAN_IO_SECURITY_CONTEXT SecurityContext,
   impl_fuse_context *impl = the_impl;
 
   if (impl->debug()) {
-    FWPRINTF(stderr, L"CreateFile : %s\n", FileName);
+    FWPRINTF(stderr, L"CreateFile : %ls\n", FileName);
     DebugConstantBit("\tDesiredAccess", DesiredAccess, cAccessMode);
     DebugConstantBit("\tShareAccess", ShareAccess, cShareMode);
     DebugConstant("\tDisposition", CreateDisposition, cDisposition);
@@ -206,7 +206,7 @@ static void DOKAN_CALLBACK FuseCloseFile(LPCWSTR FileName,
                                          PDOKAN_FILE_INFO DokanFileInfo) {
   impl_fuse_context *impl = the_impl;
   if (impl->debug())
-    FWPRINTF(stderr, L"Close: %s\n\n", FileName);
+    FWPRINTF(stderr, L"Close: %ls\n\n", FileName);
 
   impl_chain_guard guard(impl, DokanFileInfo->ProcessId);
   impl->close_file(FileName, DokanFileInfo);
@@ -218,7 +218,7 @@ static NTSTATUS DOKAN_CALLBACK FuseReadFile(LPCWSTR FileName, LPVOID Buffer,
                                             PDOKAN_FILE_INFO DokanFileInfo) {
   impl_fuse_context *impl = the_impl;
   if (impl->debug())
-    FWPRINTF(stderr, L"ReadFile : %s from %I64d len %u\n", FileName,
+    FWPRINTF(stderr, L"ReadFile : %ls from %I64d len %u\n", FileName,
              (__int64)Offset, (unsigned)BufferLength);
 
   impl_chain_guard guard(impl, DokanFileInfo->ProcessId);
@@ -233,7 +233,7 @@ static NTSTATUS DOKAN_CALLBACK FuseWriteFile(LPCWSTR FileName, LPCVOID Buffer,
                                              PDOKAN_FILE_INFO DokanFileInfo) {
   impl_fuse_context *impl = the_impl;
   if (impl->debug())
-    FWPRINTF(stderr, L"WriteFile : %s, offset %I64d, length %lu\n", FileName,
+    FWPRINTF(stderr, L"WriteFile : %ls, offset %I64d, length %lu\n", FileName,
              Offset, NumberOfBytesToWrite);
 
   impl_chain_guard guard(impl, DokanFileInfo->ProcessId);
@@ -246,7 +246,7 @@ static NTSTATUS DOKAN_CALLBACK
 FuseFlushFileBuffers(LPCWSTR FileName, PDOKAN_FILE_INFO DokanFileInfo) {
   impl_fuse_context *impl = the_impl;
   if (impl->debug())
-    FWPRINTF(stderr, L"FlushFileBuffers : %s\n", FileName);
+    FWPRINTF(stderr, L"FlushFileBuffers : %ls\n", FileName);
 
   impl_chain_guard guard(impl, DokanFileInfo->ProcessId);
   return errno_to_ntstatus_error(
@@ -258,7 +258,7 @@ static NTSTATUS DOKAN_CALLBACK FuseGetFileInformation(
     PDOKAN_FILE_INFO DokanFileInfo) {
   impl_fuse_context *impl = the_impl;
   if (impl->debug())
-    FWPRINTF(stderr, L"GetFileInfo : %s\n", FileName);
+    FWPRINTF(stderr, L"GetFileInfo : %ls\n", FileName);
 
   impl_chain_guard guard(impl, DokanFileInfo->ProcessId);
   return errno_to_ntstatus_error(impl->get_file_information(
@@ -269,7 +269,7 @@ static NTSTATUS DOKAN_CALLBACK FuseDeleteFile(LPCWSTR FileName,
                                               PDOKAN_FILE_INFO DokanFileInfo) {
   impl_fuse_context *impl = the_impl;
   if (impl->debug())
-    FWPRINTF(stderr, L"DeleteFile %s\n", FileName);
+    FWPRINTF(stderr, L"DeleteFile %ls\n", FileName);
 
   impl_chain_guard guard(impl, DokanFileInfo->ProcessId);
   return errno_to_ntstatus_error(impl->delete_file(FileName, DokanFileInfo));
@@ -281,7 +281,7 @@ FuseMoveFile(LPCWSTR FileName, // existing file name
              PDOKAN_FILE_INFO DokanFileInfo) {
   impl_fuse_context *impl = the_impl;
   if (impl->debug())
-    FWPRINTF(stderr, L"MoveFile %s -> %s\n\n", FileName, NewFileName);
+    FWPRINTF(stderr, L"MoveFile %ls -> %ls\n\n", FileName, NewFileName);
 
   impl_chain_guard guard(impl, DokanFileInfo->ProcessId);
   return errno_to_ntstatus_error(
@@ -294,7 +294,7 @@ static NTSTATUS DOKAN_CALLBACK FuseLockFile(LPCWSTR FileName,
                                             PDOKAN_FILE_INFO DokanFileInfo) {
   impl_fuse_context *impl = the_impl;
   if (impl->debug())
-    FWPRINTF(stderr, L"LockFile %s\n", FileName);
+    FWPRINTF(stderr, L"LockFile %ls\n", FileName);
 
   impl_chain_guard guard(impl, DokanFileInfo->ProcessId);
   return errno_to_ntstatus_error(
@@ -307,7 +307,7 @@ static NTSTATUS DOKAN_CALLBACK FuseUnlockFile(LPCWSTR FileName,
                                               PDOKAN_FILE_INFO DokanFileInfo) {
   impl_fuse_context *impl = the_impl;
   if (impl->debug())
-    FWPRINTF(stderr, L"UnlockFile %s\n", FileName);
+    FWPRINTF(stderr, L"UnlockFile %ls\n", FileName);
 
   impl_chain_guard guard(impl, DokanFileInfo->ProcessId);
   return errno_to_ntstatus_error(
@@ -318,7 +318,7 @@ static NTSTATUS DOKAN_CALLBACK FuseSetEndOfFile(
     LPCWSTR FileName, LONGLONG ByteOffset, PDOKAN_FILE_INFO DokanFileInfo) {
   impl_fuse_context *impl = the_impl;
   if (impl->debug())
-    FWPRINTF(stderr, L"SetEndOfFile %s, %I64d\n", FileName, ByteOffset);
+    FWPRINTF(stderr, L"SetEndOfFile %ls, %I64d\n", FileName, ByteOffset);
 
   impl_chain_guard guard(impl, DokanFileInfo->ProcessId);
   return errno_to_ntstatus_error(
@@ -329,7 +329,7 @@ static NTSTATUS DOKAN_CALLBACK FuseSetAllocationSize(
   LPCWSTR FileName, LONGLONG ByteOffset, PDOKAN_FILE_INFO DokanFileInfo) {
   impl_fuse_context *impl = the_impl;
   if (impl->debug())
-    FWPRINTF(stderr, L"SetAllocationSize %s, %I64d\n", FileName, ByteOffset);
+    FWPRINTF(stderr, L"SetAllocationSize %ls, %I64d\n", FileName, ByteOffset);
 
   impl_chain_guard guard(impl, DokanFileInfo->ProcessId);
 
@@ -364,7 +364,7 @@ static NTSTATUS DOKAN_CALLBACK FuseSetFileAttributes(
     LPCWSTR FileName, DWORD FileAttributes, PDOKAN_FILE_INFO DokanFileInfo) {
   impl_fuse_context *impl = the_impl;
   if (impl->debug())
-    FWPRINTF(stderr, L"SetFileAttributes %s\n", FileName);
+    FWPRINTF(stderr, L"SetFileAttributes %ls\n", FileName);
 
   impl_chain_guard guard(impl, DokanFileInfo->ProcessId);
   return errno_to_ntstatus_error(
@@ -378,7 +378,7 @@ static NTSTATUS DOKAN_CALLBACK FuseSetFileTime(LPCWSTR FileName,
                                                PDOKAN_FILE_INFO DokanFileInfo) {
   impl_fuse_context *impl = the_impl;
   if (impl->debug())
-    FWPRINTF(stderr, L"SetFileTime %s\n", FileName);
+    FWPRINTF(stderr, L"SetFileTime %ls\n", FileName);
 
   impl_chain_guard guard(impl, DokanFileInfo->ProcessId);
   return errno_to_ntstatus_error(impl->set_file_time(

--- a/dokan_fuse/src/fuse_helpers.c
+++ b/dokan_fuse/src/fuse_helpers.c
@@ -193,7 +193,7 @@ int fuse_daemonize(int foreground)
 		/** No daemons on Windows but we detach from current console **/
 		if (FreeConsole() == 0) {
 			DWORD currentError = GetLastError();
-			fprintf(stderr, "fuse: daemonize failed = %d\n", currentError);
+			fprintf(stderr, "fuse: daemonize failed = %lu\n", currentError);
 			return -1;
 		}
 #endif


### PR DESCRIPTION
In dokan_fuse debug output the filenames are now printed out using %ls
in order to be compliant with the C++ standard and thus make the
printing work when compiling with GCC/MingW (without the printing would stop after the first character, if the second byte is NULL)

MSVC will happily print a wide-character-string when using %s but will
fail to print out single-byte strings. *This has to be kept in mind
when printing out single-byte strings using wide-character fwprintf*.

MSVC14 supports defining _CRT_STDIO_ISO_WIDE_SPECIFIERS to bring their
format-string handling in line with the standards.

From what I have read, Microsoft's decision to be not in line with the standard was to simplify compiling the same code-base for both unicode- and non-unicode systems back in the days. They tried to change it with MSVC14, but that was too much of a headache it seems. So I guess that is why now one has to define a macro to enable standard-compliant behaviour.... oh well...

https://blogs.msdn.microsoft.com/vcblog/2014/06/18/c-runtime-crt-features-fixes-and-breaking-changes-in-visual-studio-14-ctp1/

*Please test a compile with MSVC if you can (the actual debug-prints, not only the compiling itself). I only tried a test-program to check that the behaviour is as described above on MSVC. I am lacking a driver using dokan_fuse that compiles on MSVC.* 