### PR TITLE
dokan_wix: Fix KB3033929-check

### DIFF
--- a/dokan_wix/Dokan_x64.wxs
+++ b/dokan_wix/Dokan_x64.wxs
@@ -66,8 +66,8 @@
     <Property Id="WIN7KB3033929INSTALLED" Secure="yes">
       <DirectorySearch Id="searchSystem3" Path="[SystemFolder]" Depth="0">
         <FileSearch Id="WINTRUST_FileSearch"
-                    Name="Wintrust.dll"
-                    MinVersion="6.1.7601.18741"/>
+                    Name="wintrust.dll"
+                    MinVersion="6.1.7601.18740"/>
       </DirectorySearch>
     </Property>
 

--- a/dokan_wix/Dokan_x86.wxs
+++ b/dokan_wix/Dokan_x86.wxs
@@ -64,8 +64,8 @@
     <Property Id="WIN7KB3033929INSTALLED" Secure="yes">
       <DirectorySearch Id="searchSystem3" Path="[SystemFolder]" Depth="0">
         <FileSearch Id="WINTRUST_FileSearch"
-                    Name="Wintrust.dll"
-                    MinVersion="6.1.7601.18741"/>
+                    Name="wintrust.dll"
+                    MinVersion="6.1.7601.18740"/>
       </DirectorySearch>
     </Property>
 


### PR DESCRIPTION
**Not yet tested, don't merge**

Due to some oddity, we need to specify a version that is one version
lower than the one we are actually searching for.
References: #260, #244, #187

Quoting WiX-documentation:
Important: When doing a locale-neutral search for a file, you must set
the MinVersion property to one revision number lower than the actual
version you want to search for.