### PR TITLE
fix coverity issues with freeing fileName and parentDir when device is read-only

### DIFF
--- a/sys/create.c
+++ b/sys/create.c
@@ -642,16 +642,13 @@ Return Value:
         __leave;
       }
     }
-    
+
     if (irpSp->Flags & SL_OPEN_TARGET_DIRECTORY) {
       status = DokanGetParentDir(fileName, &parentDir, &parentDirLength);
       if (status != STATUS_SUCCESS) {
         ExFreePool(fileName);
         __leave;
       }
-    }
-
-    if (irpSp->Flags & SL_OPEN_TARGET_DIRECTORY) {
       fcb = DokanGetFCB(vcb, parentDir, parentDirLength);
     } else {
       fcb = DokanGetFCB(vcb, fileName, fileNameLength);

--- a/sys/create.c
+++ b/sys/create.c
@@ -626,14 +626,6 @@ Return Value:
                     fileObject->FileName.Length);
     }
 
-    if (irpSp->Flags & SL_OPEN_TARGET_DIRECTORY) {
-      status = DokanGetParentDir(fileName, &parentDir, &parentDirLength);
-      if (status != STATUS_SUCCESS) {
-        ExFreePool(fileName);
-        __leave;
-      }
-    }
-
     // Fail if device is read-only and request involves a write operation
     DWORD disposition = 0;
     if (IS_DEVICE_READ_ONLY(DeviceObject)) {
@@ -646,6 +638,14 @@ Return Value:
 
         DDbgPrint("    Media is write protected\n");
         status = STATUS_MEDIA_WRITE_PROTECTED;
+        ExFreePool(fileName);
+        __leave;
+      }
+    }
+    
+    if (irpSp->Flags & SL_OPEN_TARGET_DIRECTORY) {
+      status = DokanGetParentDir(fileName, &parentDir, &parentDirLength);
+      if (status != STATUS_SUCCESS) {
         ExFreePool(fileName);
         __leave;
       }


### PR DESCRIPTION
I moved the code down to fix the coverity issue with fileName and parentDir if the device is read-only.

Then I realized I should just merge it with the block below it.  Otherwise there is a redundant check for SL_OPEN_TARGET_DIRECTORY.