### PR TITLE
Fix rename in root dir

### DIFF
--- a/dokan/create.c
+++ b/dokan/create.c
@@ -179,6 +179,11 @@ VOID DispatchCreate(HANDLE Handle, // This handle is not for a file. It is for
     if (lastP) {
       *lastP = 0;
     }
+    
+    if (!fileName[0]) {
+      fileName[0] = '\\';
+      fileName[1] = 0;
+    }
   }
 
   DbgPrint("###Create %04d\n", eventId);
@@ -262,12 +267,6 @@ VOID DispatchCreate(HANDLE Handle, // This handle is not for a file. It is for
     }
     eventInfo.Operation.Create.Information = FILE_DOES_NOT_EXIST;
     eventInfo.Status = status;
-
-    if (status == STATUS_OBJECT_NAME_NOT_FOUND &&
-        EventContext->Flags & SL_OPEN_TARGET_DIRECTORY) {
-      DbgPrint("This case should be returned as SUCCESS\n");
-      eventInfo.Status = STATUS_SUCCESS;
-    }
 
     if (status == STATUS_OBJECT_NAME_COLLISION) {
       eventInfo.Operation.Create.Information = FILE_EXISTS;

--- a/sys/create.c
+++ b/sys/create.c
@@ -284,28 +284,20 @@ NTSTATUS DokanGetParentDir(__in const WCHAR *fileName, __out WCHAR **parentDir,
   LONG len = (LONG)wcslen(fileName);
 
   LONG i;
-  ULONG nSlashes = 0;
+
   BOOLEAN trailingSlash;
 
   *parentDir = NULL;
   *parentDirLength = 0;
+  
+  if (len < 1) {
+	  return STATUS_INVALID_PARAMETER;
+  }
 
-  if (len < 4)
+  if (!wcscmp(fileName, L"\\"))
     return STATUS_ACCESS_DENIED;
 
   trailingSlash = fileName[len - 1] == '\\';
-
-  if (trailingSlash && len < 5)
-    return STATUS_ACCESS_DENIED;
-
-  for (i = 0; i < len; i++) {
-    if (fileName[i] == '\\') {
-      nSlashes++;
-    }
-  }
-
-  if (nSlashes < (ULONG)(trailingSlash ? 3 : 2))
-    return STATUS_ACCESS_DENIED;
 
   *parentDir = (WCHAR *)ExAllocatePool((len + 1) * sizeof(WCHAR));
 
@@ -323,8 +315,15 @@ NTSTATUS DokanGetParentDir(__in const WCHAR *fileName, __out WCHAR **parentDir,
       break;
     }
   }
+  
+  if (i <= 0) {
+	  i = 1;
+	  (*parentDir)[0] = '\\';
+    (*parentDir)[1] = 0;
+  }
+	  
   *parentDirLength = i * sizeof(WCHAR);
-  if (trailingSlash) {
+  if (trailingSlash  && i > 1) {
     (*parentDir)[i] = '\\';
     (*parentDir)[i + 1] = 0;
     *parentDirLength += sizeof(WCHAR);


### PR DESCRIPTION
This has to do with SL_OPEN_TARGET_DIRECTORY

Both the the code I added in the driver, and the code that was already there in dokan\create.c for getting the parent directory would turn a path like \foo.txt into an empty string when trying to get the parent directory.

This was preventing files in the root of the mirror fs from being renamed.

I fixed both of them to get \ in that case.

Also, I noticed that dokan\creat.c was returning STATUS_SUCCESS even if opening the parent dir failed.  It shouldn't do that.  It should return success if the parent can be opened but the child does not exist.  It shouldn't return success if the parent cannot be opened.
