### PR TITLE
should not free eventContext, ccb, or fcb if oplock is pending

### DIFF
--- a/sys/create.c
+++ b/sys/create.c
@@ -1045,9 +1045,6 @@ create is over.
         DDbgPrint("   FsRtlCheckOplock returned STATUS_PENDING, fileName = "
                   "%wZ, fileCount = %lu\n",
                   fcb->FileName, fcb->FileCount);
-        DokanFreeEventContext(eventContext);
-        DokanFreeCCB(ccb);
-        DokanFreeFCB(fcb);
         __leave;
       }
     }


### PR DESCRIPTION
I noticed this happening 

```
M:\ echo blah > foo.txt
M:\ del foo.txt
[hang]
```

The cmd window is hung.  The driver and mirror are still ok. 

If I disabled Windows Defender real-time scanning, it didn't happen.

When I fixed the leaks that happened because of leaving early from the failed oplock operation, I also "fixed" a non-leak in the case above it, where the the oplock is pending. In that case, the operation is registered as pending, and no additional freeing is necessary or desirable.

Here is the fix 