### PR TITLE
sys: Add IsUnmounting to the DCB

### DIFF
--- a/sys/dokan.h
+++ b/sys/dokan.h
@@ -225,6 +225,7 @@ typedef struct _DokanDiskControlBlock {
   USHORT UseMountManager;
   USHORT MountGlobally;
   USHORT FileLockInUserMode;
+  USHORT IsUnmounting;
 
   // to make a unique id for pending IRP
   ULONG SerialNumber;

--- a/sys/notification.c
+++ b/sys/notification.c
@@ -417,6 +417,7 @@ NTSTATUS DokanEventRelease(__in PDEVICE_OBJECT DeviceObject) {
     return STATUS_INVALID_PARAMETER;
   }
   dcb = vcb->Dcb;
+  dcb->IsUnmounting = 1;
 
   DokanDeleteMountPoint(dcb);
 


### PR DESCRIPTION
As suggested by @marinkobabic on https://github.com/dokan-dev/dokany/issues/272

I can get this to hit occasionally in stress tests. 

However this does not replace https://github.com/dokan-dev/dokany/pull/280