### PR TITLE
fix for WriteFile() of length zero byes

### DIFF
--- a/sys/read.c
+++ b/sys/read.c
@@ -65,6 +65,7 @@ Return Value:
     //  If this is a zero length read then return SUCCESS immediately.
     //
     if (irpSp->Parameters.Read.Length == 0) {
+      Irp->IoStatus.Information = 0;
       DDbgPrint("  Parameters.Read.Length == 0 \n");
       status = STATUS_SUCCESS;
       __leave;

--- a/sys/read.c
+++ b/sys/read.c
@@ -65,8 +65,8 @@ Return Value:
     //  If this is a zero length read then return SUCCESS immediately.
     //
     if (irpSp->Parameters.Read.Length == 0) {
-      Irp->IoStatus.Information = 0;
       DDbgPrint("  Parameters.Read.Length == 0 \n");
+      Irp->IoStatus.Information = 0;
       status = STATUS_SUCCESS;
       __leave;
     }

--- a/sys/write.c
+++ b/sys/write.c
@@ -43,9 +43,12 @@ DokanDispatchWrite(__in PDEVICE_OBJECT DeviceObject, __in PIRP Irp) {
     //
     //  If this is a zero length write then return SUCCESS immediately.
     //
-    if (irpSp->Parameters.Write.Length == 0) {
-
-      DDbgPrint("  Parameters.Write.Length == 0") return STATUS_SUCCESS;
+    
+     if (irpSp->Parameters.Write.Length == 0) {
+      DDbgPrint("  Parameters.Write.Length == 0\n");
+      Irp->IoStatus.Information = 0;
+      status = STATUS_SUCCESS;
+      __leave;
     }
 
     if (fileObject == NULL) {
@@ -73,11 +76,6 @@ DokanDispatchWrite(__in PDEVICE_OBJECT DeviceObject, __in PIRP Irp) {
 
     if (fcb->Flags & DOKAN_FILE_DIRECTORY) {
       status = STATUS_INVALID_PARAMETER;
-      __leave;
-    }
-
-    if (irpSp->Parameters.Write.Length == 0) {
-      status = STATUS_SUCCESS;
       __leave;
     }
 

--- a/sys/write.c
+++ b/sys/write.c
@@ -44,7 +44,7 @@ DokanDispatchWrite(__in PDEVICE_OBJECT DeviceObject, __in PIRP Irp) {
     //  If this is a zero length write then return SUCCESS immediately.
     //
     
-     if (irpSp->Parameters.Write.Length == 0) {
+    if (irpSp->Parameters.Write.Length == 0) {
       DDbgPrint("  Parameters.Write.Length == 0\n");
       Irp->IoStatus.Information = 0;
       status = STATUS_SUCCESS;


### PR DESCRIPTION
when writing zero bytes, complete irp normally.  also when reading or… writing zero bytes set Irp->IoStatus.Information = 0

this is about https://github.com/dokan-dev/dokany/issues/299