### PR TITLE
sys: FCB unlock on some error paths

### DIFF
--- a/sys/cleanup.c
+++ b/sys/cleanup.c
@@ -92,6 +92,7 @@ Return Value:
 
     if (eventContext == NULL) {
       status = STATUS_INSUFFICIENT_RESOURCES;
+      DokanFCBUnlock(fcb);
       __leave;
     }
 

--- a/sys/create.c
+++ b/sys/create.c
@@ -256,7 +256,9 @@ DokanFreeCCB(__in PDokanCCB ccb) {
   if (IsListEmpty(&ccb->NextCCB)) {
     DDbgPrint("  WARNING. &ccb->NextCCB is empty. \n This should never happen, "
               "so check the behavior.\n Would produce BSOD "
-              "\n") return STATUS_SUCCESS;
+              "\n");
+    DokanFCBUnlock(fcb);
+    return STATUS_SUCCESS;
   } else {
     RemoveEntryList(&ccb->NextCCB);
     InitializeListHead(&ccb->NextCCB);
@@ -400,6 +402,7 @@ Otherwise, STATUS_SHARING_VIOLATION is returned.
       MmDoesFileHaveUserWritableReferences(&FcbOrDcb->SectionObjectPointers)) {
 
     DDbgPrint("  DokanCheckShareAccess FCB has no write shared access\n");
+    DokanFCBUnlock(FcbOrDcb);
     return STATUS_SHARING_VIOLATION;
   }
 #endif

--- a/sys/directory.c
+++ b/sys/directory.c
@@ -175,6 +175,7 @@ DokanQueryDirectory(__in PDEVICE_OBJECT DeviceObject, __in PIRP Irp) {
           ExAllocatePool(ccb->SearchPatternLength + sizeof(WCHAR));
 
       if (ccb->SearchPattern == NULL) {
+        DokanFCBUnlock(fcb);
         return STATUS_INSUFFICIENT_RESOURCES;
       }
 
@@ -199,6 +200,7 @@ DokanQueryDirectory(__in PDEVICE_OBJECT DeviceObject, __in PIRP Irp) {
   eventContext = AllocateEventContext(vcb->Dcb, Irp, eventLength, ccb);
 
   if (eventContext == NULL) {
+    DokanFCBUnlock(fcb);
     return STATUS_INSUFFICIENT_RESOURCES;
   }
 
@@ -284,6 +286,7 @@ DokanNotifyChangeDirectory(__in PDEVICE_OBJECT DeviceObject, __in PIRP Irp) {
   DokanFCBLockRO(fcb);
 
   if (!(fcb->Flags & DOKAN_FILE_DIRECTORY)) {
+    DokanFCBUnlock(fcb);
     return STATUS_INVALID_PARAMETER;
   }
 

--- a/sys/flush.c
+++ b/sys/flush.c
@@ -26,7 +26,7 @@ DokanDispatchFlush(__in PDEVICE_OBJECT DeviceObject, __in PIRP Irp) {
   PIO_STACK_LOCATION irpSp;
   PFILE_OBJECT fileObject;
   NTSTATUS status = STATUS_INVALID_PARAMETER;
-  PDokanFCB fcb;
+  PDokanFCB fcb = NULL;
   PDokanCCB ccb;
   PDokanVCB vcb;
   PEVENT_CONTEXT eventContext;
@@ -81,7 +81,6 @@ DokanDispatchFlush(__in PDEVICE_OBJECT DeviceObject, __in PIRP Irp) {
 
     status = FsRtlCheckOplock(DokanGetFcbOplock(fcb), Irp, eventContext,
                               DokanOplockComplete, DokanPrePostIrp);
-    DokanFCBUnlock(fcb);
 
     //
     //  if FsRtlCheckOplock returns STATUS_PENDING the IRP has been posted
@@ -100,6 +99,8 @@ DokanDispatchFlush(__in PDEVICE_OBJECT DeviceObject, __in PIRP Irp) {
     status = DokanRegisterPendingIrp(DeviceObject, Irp, eventContext, 0);
 
   } __finally {
+    if(fcb)
+      DokanFCBUnlock(fcb);
 
     DokanCompleteIrpRequest(Irp, status, 0);
 


### PR DESCRIPTION
Found some error paths that were still lacking proper locks when reviewing the code for the third time.