### PR TITLE
sys: Use FCB locks for CCBs

### DIFF
--- a/sys/dokan.h
+++ b/sys/dokan.h
@@ -368,19 +368,31 @@ typedef struct _DokanFileControlBlock {
 //#define DokanFCBUnlock(fcb) do { DDbgPrint("ZZZ Unlock %s", __FUNCTION__); KeEnterCriticalRegion(); ExReleaseResourceLite(&fcb->Resource); KeLeaveCriticalRegion(); } while(0)
 
 typedef struct _DokanContextControlBlock {
+  // Locking: read-only no locking needed.
   FSD_IDENTIFIER Identifier;
-  ERESOURCE Resource;
+  // Use FCB locks for locking data members.
+  //ERESOURCE Resource;
+
+  // Fcb is a read-only pointer to the FCB - never NULL.
+  // Locking: read-only - no locking needed.
   PDokanFCB Fcb;
+  // Locking: Lock the *FCB* with DokanFCBLock{RO,RW}.
   LIST_ENTRY NextCCB;
+  // Context is used to store the index inside a directory in directory.c
+  // Locking: Lock the *FCB*
   ULONG64 Context;
+  // Locking: FIXME
   ULONG64 UserContext;
 
+  // Locking: Lock the *FCB*
   PWCHAR SearchPattern;
+  // Locking: like SearchPattern.
   ULONG SearchPatternLength;
 
+  // Locking: 32bit field - reads are atomic, writes with DokanFCBLockRW.
   ULONG Flags;
 
-  int FileCount;
+  // Locking: read-only - no locking needed.
   ULONG MountId;
 } DokanCCB, *PDokanCCB;
 


### PR DESCRIPTION
This might be somewhat controversial - it simplifies some things - and requires less locks - but might be pessimistic in cases with a lot of lock contention.

There is no hurry to merge this and doing this in another way might be sensible :)

Should we use separate CCB locks?

Merging the locks means:
+ Somewhat simpler code
+ Somewhat smaller CCBs and less locks around
+ No need to be careful to take FCB and CCB locks in the right sequence
+ In places where both  FCB and CCB lock would be used just the FCB lock suffices
+ Which can be faster if there is not very much contention
- We take an FCB lock in a few places where a CCB specific one would suffice
- Which can be slower if there is lots of contention

I have left UserContext alone with this patch.

Looking forward to discuss this :)