### PR TITLE
Appveyor: Upgrade all Cygwin packages before build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@
           
           function updateCygwin($cygwinexe, $installFolder, $cacheFolder) {
             Write-Host "Update Cygwin: " $cygwinexe -NoNewline
-            cmd /c start /wait $cygwinexe -qnNdO -R $installFolder -s http://mirrors.kernel.org/sourceware/cygwin/ -l $cacheFolder -P mingw64-i686-gcc-g++ -P mingw64-x86_64-gcc-g++ -P gcc-g++-5.3.0-5 -P make -P cmake
+            cmd /c start /wait $cygwinexe -gqnNdO -R $installFolder -s http://mirrors.kernel.org/sourceware/cygwin/ -l $cacheFolder -P mingw64-i686-gcc-g++ -P mingw64-x86_64-gcc-g++ -P gcc-g++-5.3.0-5 -P make -P cmake
             Write-Host " - OK" -ForegroundColor Green
           }
           


### PR DESCRIPTION
Upgrading all packages ensures that we are running the latest Cygwin.
Sometimes dependencies of packages are incorrect and dependant packages
are thus not upgraded automatically when they should be.

This makes the Appveyor build working again after the cmake-package in
Cygwin was upgraded a few days ago breaking our build. Closes #335.