### PR TITLE
Use atomic operations for FCB and CCB flags instead of locks

### DIFF
--- a/sys/cleanup.c
+++ b/sys/cleanup.c
@@ -107,7 +107,7 @@ Return Value:
     fileObject->Flags |= FO_CLEANUP_COMPLETE;
 
     eventContext->Context = ccb->UserContext;
-    eventContext->FileFlags |= ccb->Flags;
+    eventContext->FileFlags |= DokanCCBFlagsGet(ccb);
     // DDbgPrint("   get Context %X\n", (ULONG)ccb->UserContext);
 
     // copy the filename to EventContext from ccb
@@ -177,8 +177,8 @@ VOID DokanCompleteCleanup(__in PIRP_ENTRY IrpEntry,
 
   status = EventInfo->Status;
 
-  if (FlagOn(fcb->Flags, DOKAN_DELETE_ON_CLOSE)) {
-    if (fcb->Flags & DOKAN_FILE_DIRECTORY) {
+  if (DokanFCBFlagsIsSet(fcb, DOKAN_DELETE_ON_CLOSE)) {
+    if (DokanFCBFlagsIsSet(fcb, DOKAN_FILE_DIRECTORY)) {
       DokanNotifyReportChange(fcb, FILE_NOTIFY_CHANGE_DIR_NAME,
                               FILE_ACTION_REMOVED);
     } else {
@@ -193,7 +193,7 @@ VOID DokanCompleteCleanup(__in PIRP_ENTRY IrpEntry,
   (VOID) FsRtlFastUnlockAll(&fcb->FileLock, fileObject,
                             IoGetRequestorProcess(irp), NULL);
 
-  if (fcb->Flags & DOKAN_FILE_DIRECTORY) {
+  if (DokanFCBFlagsIsSet(fcb, DOKAN_FILE_DIRECTORY)) {
     FsRtlNotifyCleanup(vcb->NotifySync, &vcb->DirNotifyList, ccb);
   }
 

--- a/sys/dokan.h
+++ b/sys/dokan.h
@@ -336,7 +336,7 @@ typedef struct _DokanFileControlBlock {
   // Locking: DokanFCBLock{RO,RW}
   LONG FileCount;
 
-  // Locking: DokanFCBLock{RO,RW}
+  // Locking: Use atomic flag operations - DokanFCBFlags*
   ULONG Flags;
   // Locking: DokanFCBLock{RO,RW}
   SHARE_ACCESS ShareAccess;
@@ -378,6 +378,7 @@ typedef struct _DokanContextControlBlock {
   PWCHAR SearchPattern;
   ULONG SearchPatternLength;
 
+  // Locking: Use atomic flag operations - DokanCCBFlags*
   ULONG Flags;
 
   int FileCount;
@@ -708,5 +709,16 @@ __inline VOID DokanClearFlag(PULONG Flags, ULONG FlagBit) {
 }
 
 #define IsFlagOn(a, b) ((BOOLEAN)(FlagOn(a, b) == b))
+
+#define DokanFCBFlagsGet(fcb) ((fcb)->Flags)
+#define DokanFCBFlagsIsSet(fcb, bit) (((fcb)->Flags)&(bit))
+#define DokanFCBFlagsSetBit(fcb, bit) SetLongFlag((fcb)->Flags, (bit))
+#define DokanFCBFlagsClearBit(fcb, bit) ClearLongFlag((fcb)->Flags, (bit))
+
+#define DokanCCBFlagsGet DokanFCBFlagsGet
+#define DokanCCBFlagsIsSet DokanFCBFlagsIsSet
+#define DokanCCBFlagsSetBit DokanFCBFlagsSetBit
+#define DokanCCBFlagsClearBit DokanFCBFlagsClearBit
+
 
 #endif // DOKAN_H_

--- a/sys/fileinfo.c
+++ b/sys/fileinfo.c
@@ -570,15 +570,15 @@ VOID DokanCompleteSetInformation(__in PIRP_ENTRY IrpEntry,
             DDbgPrint("  Cannot delete user mapped image\n");
             status = STATUS_CANNOT_DELETE;
           } else {
-            ccb->Flags |= DOKAN_DELETE_ON_CLOSE;
-            fcb->Flags |= DOKAN_DELETE_ON_CLOSE;
+            DokanCCBFlagsSetBit(ccb, DOKAN_DELETE_ON_CLOSE);
+            DokanFCBFlagsSetBit(fcb, DOKAN_DELETE_ON_CLOSE);
             DDbgPrint("   FileObject->DeletePending = TRUE\n");
             IrpEntry->FileObject->DeletePending = TRUE;
           }
 
         } else {
-          ccb->Flags &= ~DOKAN_DELETE_ON_CLOSE;
-          fcb->Flags &= ~DOKAN_DELETE_ON_CLOSE;
+          DokanCCBFlagsClearBit(ccb, DOKAN_DELETE_ON_CLOSE);
+          DokanFCBFlagsClearBit(fcb, DOKAN_DELETE_ON_CLOSE);
           DDbgPrint("   FileObject->DeletePending = FALSE\n");
           IrpEntry->FileObject->DeletePending = FALSE;
         }
@@ -636,7 +636,7 @@ VOID DokanCompleteSetInformation(__in PIRP_ENTRY IrpEntry,
         break;
       case FileDispositionInformation:
         if (IrpEntry->FileObject->DeletePending) {
-          if (fcb->Flags & DOKAN_FILE_DIRECTORY) {
+          if (DokanFCBFlagsIsSet(fcb, DOKAN_FILE_DIRECTORY)) {
             DokanNotifyReportChange(fcb, FILE_NOTIFY_CHANGE_DIR_NAME,
                                     FILE_ACTION_REMOVED);
           } else {

--- a/sys/fscontrol.c
+++ b/sys/fscontrol.c
@@ -101,8 +101,7 @@ NTSTATUS DokanOplockRequest(__in PIRP *pIrp) {
   //  Read-Handle
   //  oplock only.
   //
-  // FIXME - should we synchronize access here on Fcb->Flags?
-  if (FlagOn(Fcb->Flags, DOKAN_FILE_DIRECTORY) &&
+  if ((DokanFCBFlagsIsSet(Fcb, DOKAN_FILE_DIRECTORY)) &&
       ((FsControlCode != FSCTL_REQUEST_OPLOCK) ||
        !FsRtlOplockIsSharedRequest(Irp))) {
 
@@ -144,7 +143,7 @@ NTSTATUS DokanOplockRequest(__in PIRP *pIrp) {
         //
         //  Byte-range locks are only valid on files.
         //
-        if (!FlagOn(Fcb->Flags, DOKAN_FILE_DIRECTORY)) {
+        if (!DokanFCBFlagsIsSet(Fcb, DOKAN_FILE_DIRECTORY)) {
 
 //
 //  Set OplockCount to nonzero if FsRtl denies access
@@ -205,7 +204,7 @@ NTSTATUS DokanOplockRequest(__in PIRP *pIrp) {
           FlagOn(InputBuffer->RequestedOplockLevel, OPLOCK_LEVEL_CACHE_HANDLE))
 #endif
              ) &&
-        FlagOn(Fcb->Flags, DOKAN_DELETE_ON_CLOSE)) {
+        DokanFCBFlagsIsSet(Fcb, DOKAN_DELETE_ON_CLOSE)) {
 
       DDbgPrint("    DokanOplockRequest STATUS_DELETE_PENDING\n");
       return STATUS_DELETE_PENDING;

--- a/sys/lock.c
+++ b/sys/lock.c
@@ -49,18 +49,17 @@ DokanCommonLockControl(__in PIRP Irp) {
     DDbgPrint("    DokanOplockRequest STATUS_INVALID_PARAMETER\n");
     return STATUS_INVALID_PARAMETER;
   }
-  DokanFCBLockRW(Fcb);
 
   //
   //  If the file is not a user file open then we reject the request
   //  as an invalid parameter
   //
-  if (FlagOn(Fcb->Flags, DOKAN_FILE_DIRECTORY)) {
+  if (DokanFCBFlagsIsSet(Fcb, DOKAN_FILE_DIRECTORY)) {
     DDbgPrint("  DokanCommonLockControl -> STATUS_INVALID_PARAMETER\n", 0);
-    DokanFCBUnlock(Fcb);
     return STATUS_INVALID_PARAMETER;
   }
 
+  DokanFCBLockRW(Fcb);
   try {
 
 //

--- a/sys/notification.c
+++ b/sys/notification.c
@@ -71,7 +71,7 @@ VOID SetCommonEventContext(__in PDokanDCB Dcb, __in PEVENT_CONTEXT EventContext,
   EventContext->Flags = irpSp->Flags;
 
   if (Ccb) {
-    EventContext->FileFlags = Ccb->Flags;
+    EventContext->FileFlags = DokanCCBFlagsGet(Ccb);
   }
 
   EventContext->ProcessId = IoGetRequestorProcessId(Irp);

--- a/sys/volume.c
+++ b/sys/volume.c
@@ -244,7 +244,7 @@ DokanDispatchQueryVolumeInformation(__in PDEVICE_OBJECT DeviceObject,
 
       if (ccb) {
         eventContext->Context = ccb->UserContext;
-        eventContext->FileFlags = ccb->Flags;
+        eventContext->FileFlags = DokanCCBFlagsGet(ccb);
         // DDbgPrint("   get Context %X\n", (ULONG)ccb->UserContext);
       }
 

--- a/sys/write.c
+++ b/sys/write.c
@@ -79,15 +79,10 @@ DokanDispatchWrite(__in PDEVICE_OBJECT DeviceObject, __in PIRP Irp) {
     fcb = ccb->Fcb;
     ASSERT(fcb != NULL);
 
-    DokanFCBLockRO(fcb);
-    fcbLocked = TRUE;
-    if (fcb->Flags & DOKAN_FILE_DIRECTORY) {
+    if (DokanFCBFlagsIsSet(fcb, DOKAN_FILE_DIRECTORY)) {
       status = STATUS_INVALID_PARAMETER;
       __leave;
     }
-    // Drop lock here, consider atomic flag access in the future,
-    DokanFCBUnlock(fcb);
-    fcbLocked = FALSE;
 
     if (Irp->MdlAddress) {
       DDbgPrint("  use MdlAddress\n");


### PR DESCRIPTION
* Go through all Flags access for FCBs and CCBs
* Use helpers for access
* Make modification of flags use atomic operations
* Locks need to be held for less time because they are not needed for flags anymore