### PR TITLE
MirrorCreateFile - Reject when trying to open a file as a directory

### DIFF
--- a/samples/dokan_mirror/mirror.c
+++ b/samples/dokan_mirror/mirror.c
@@ -326,6 +326,13 @@ MirrorCreateFile(LPCWSTR FileName, PDOKAN_IO_SECURITY_CONTEXT SecurityContext,
       }
     }
     if (status == STATUS_SUCCESS) {
+      //Check first if we're trying to open a file as a directory.
+      if (fileAttr != INVALID_FILE_ATTRIBUTES &&
+          !(fileAttr & FILE_ATTRIBUTE_DIRECTORY) &&
+          (CreateOptions & FILE_DIRECTORY_FILE)) {
+        return STATUS_NOT_A_DIRECTORY;
+      }
+
       // FILE_FLAG_BACKUP_SEMANTICS is required for opening directory handles
       handle =
           CreateFile(filePath, genericDesiredAccess, ShareAccess,


### PR DESCRIPTION
STATUS_NOT_A_DIRECTORY should be returned if a file is being opened and the FILE_DIRECTORY_FILE option is used.
The problem with allowing this, is that if the file has previously been opened as a normal file, it will set the (shared) FCB as being a directory ([here](https://github.com/dokan-dev/dokany/blob/master/sys/create.c#L1360)). As such, further reads on the file will fail!