### PR TITLE
dokan_fuse: Add libfuse-compatible pkg-config

### DIFF
--- a/dokan_fuse/CMakeLists.txt
+++ b/dokan_fuse/CMakeLists.txt
@@ -7,12 +7,41 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
+option(FUSE_PKG_CONFIG "Install a libfuse-compatible pkg-config file (fuse.pc)" ON)
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -mwin32 -Wall")
 add_definitions(-D_FILE_OFFSET_BITS=64)
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/../sys
 )
+
+if(FUSE_PKG_CONFIG)
+    # Defining helper-function to deal with setups that manually set an
+    # absolute path for CMAKE_INSTALL_(LIB|INCLUDE)DIR...
+    # We could also just make all paths absolute, but this way the
+    # pkg-config-file is more human-readable and pkg-config may be able to deal
+    # with varying prefixes.
+    # CMake does not have a ternary operator for generator expressions, so this
+    # looks more complicated than it is.
+    function ( make_pkg_config_absolute out_path in_path )
+        if(IS_ABSOLUTE "${${in_path}}")
+            set(${out_path} "${${in_path}}" PARENT_SCOPE)
+        else()
+            set(${out_path} "\${prefix}/${${in_path}}" PARENT_SCOPE)
+        endif()
+    endfunction()
+
+    set(pkg_config_file "${CMAKE_CURRENT_BINARY_DIR}/fuse.pc")
+    make_pkg_config_absolute(PKG_CONFIG_LIBDIR CMAKE_INSTALL_LIBDIR)
+    make_pkg_config_absolute(PKG_CONFIG_INCLUDEDIR CMAKE_INSTALL_INCLUDEDIR)
+
+    CONFIGURE_FILE(
+        "${CMAKE_CURRENT_SOURCE_DIR}/pkg-config.pc.in"
+        ${pkg_config_file}
+        @ONLY
+    )
+endif()
 
 file(GLOB sources src/*.cpp src/*.c src/*.rc)
 set(install_headers
@@ -30,6 +59,9 @@ add_library(dokanfuse1 SHARED ${sources})
 
 INSTALL(FILES ${install_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fuse/)
 INSTALL(FILES ${compat_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if(FUSE_PKG_CONFIG)
+    INSTALL(FILES ${pkg_config_file} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+endif()
 INSTALL(TARGETS dokanfuse1
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/dokan_fuse/build.ps1
+++ b/dokan_fuse/build.ps1
@@ -10,7 +10,7 @@ $script:failed = 0
         make install"
     & C:\cygwin\bin\bash -lc "
         cd '$currentPath' &&
-        gcc -o '$installDir'/mirror samples/fuse_mirror/fusexmp.c -I '$installDir/include' -D_FILE_OFFSET_BITS=64 -L $installDir/ -lcygdokanfuse1"
+        gcc -o '$installDir'/mirror samples/fuse_mirror/fusexmp.c `$(PKG_CONFIG_PATH='$installDir/lib/pkgconfig' pkg-config fuse --cflags --libs)"
     if ($LASTEXITCODE -ne 0) {
         $script:failed = $LASTEXITCODE
     }
@@ -25,7 +25,7 @@ $script:failed = 0
         make install"
     & C:\cygwin64\bin\bash -lc "
         cd '$currentPath' &&
-        gcc -o '$installDir'/mirror samples/fuse_mirror/fusexmp.c -I '$installDir/include' -D_FILE_OFFSET_BITS=64 -L $installDir/ -lcygdokanfuse1"
+        gcc -o '$installDir'/mirror samples/fuse_mirror/fusexmp.c `$(PKG_CONFIG_PATH='$installDir/lib/pkgconfig' pkg-config fuse --cflags --libs)"
     if ($LASTEXITCODE -ne 0) {
         $script:failed = $LASTEXITCODE
     }

--- a/dokan_fuse/pkg-config.pc.in
+++ b/dokan_fuse/pkg-config.pc.in
@@ -1,0 +1,13 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@PKG_CONFIG_LIBDIR@
+includedir=@PKG_CONFIG_INCLUDEDIR@
+
+Name: Dokan FUSE
+Description: FUSE-API compatibility library for the Dokan user mode filesystem driver for Windows
+# Dokan FUSE provides compatibility with libfuse 2.6.x.
+# The corresponding libfuse-version is therefore reported instead of the Dokan FUSE-version
+Version: 2.6.0
+URL: https://dokan-dev.github.io
+Libs: -L${libdir} -l@PROJECT_NAME@
+Cflags: -I${includedir} -D_FILE_OFFSET_BITS=64


### PR DESCRIPTION
Don't merge yet. This needs further testing and input.
This fixes #338.

This generates a pkg-config-file that can be used as a drop-in "replacement" for libfuse, i.e.

```
$ pkg-config --libs --cflags fuse
```

will return the dokanfuse-flags.
# Required testing

I have only tested this on Debian Stretch. Thus, it is lacking testing on Windows. I would be happy if someone could test it on
- Cygwin
- MSYS2-Installer - MinGW-W64-32bit
- MSYS2-Installer - MinGW-W64-64bit

I currently do not have any working Windows-system at hand to test myself.

You can add `-DCMAKE_INSTALL_PREFIX="/tmp/usr/` to the cmake-invokation to define another prefix to avoid cluttering your global directories while testing. You can then use the  `PKG_CONFIG_PATH` environment-variable to point pkg-config to the right `lib/pkgconfig`-dir.
Situations to test:
- Normal installation (`cd build && cmake .. && make install`)
- Custom absolute path for LIBDIR and and INCLUDEDIR (i.e. `-DCMAKE_INSTALL_LIBDIR=/some/absolute/path/that/is/different` and `-DCMAKE_INSTALL_INCLUDEDIR=/some/absolute/path/that/is/different`).

I am a bit confused about whether we need to use LIBDIR or BINDIR, because I was unfamiliar with the Windows-only concept of "import libraries" (research shows that it had historic reasons to support compiling for OS/2 from NT without having the OS/2 DLLs).
# Discussion

The pkg-config-file will be installed as `fuse.pc`. So we kind of snatch the libfuse name. This could be considered problematic for users that prefer to have different fuse-libaries installed. I have some suggestions for that
1. Leave as it is, always install a fuse.pc
2. Add some option to cmake that allows one to disable the installation of fuse.pc ('-DINSTALL_PKG_CONFIG=OFF`)'
3. Install a second pkg-config-file `dokanfuse.pc` and add an option like `-DINSTALL_PKG_CONFIG=(both|fuse|dokanfuse|none)`, default would be both
