### PR TITLE
CI: AppVeyor speed-ups and enhancements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@
       DOKAN_CI_CACHE: C:\dokan_ci_cache
       CYG_CACHE: '%DOKAN_CI_CACHE%\cygwin'
       MSYS2_CACHE: '%DOKAN_CI_CACHE%\msys2'
+      CHOCO_CACHE: '%DOKAN_CI_CACHE%\choco'
 
   os: Visual Studio 2015
   version: 1.0.1-{build}
@@ -26,7 +27,7 @@
   install:
     - ps: |
         if ($env:CONFIGURATION -eq "All") {
-          & choco install doxygen.portable
+          & choco install "--cache-location=${env:CHOCO_CACHE}" doxygen.portable
         }
   
     - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -247,6 +247,7 @@
       }
       Write-Host Build Finished !
 
+  test: off
   on_success:
     - ps: |
         if ($env:CONFIGURATION -eq "All") {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,14 @@
   cache:
   - '%DOKAN_CI_CACHE% -> appveyor.yml'
 
+# To debug build issues, add your own fork to AppVeyor and uncomment below.
+# Connection details will be printed to the console output.
+# $blockRdp makes the build block until a file is deleted from the desktop.
+#  init:
+#    ps: Invoke-Expression (Invoke-WebRequest 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1')
+#  on_finish:
+#    ps: $blockRdp = $true; Invoke-Expression (Invoke-WebRequest 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1')
+
   install:
     - ps: |
         if ($env:CONFIGURATION -eq "All") {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@
     global:
       DOKAN_CI_CACHE: C:\dokan_ci_cache
       CYG_CACHE: '%DOKAN_CI_CACHE%\cygwin'
+      MSYS2_CACHE: '%DOKAN_CI_CACHE%\msys2'
 
   os: Visual Studio 2015
   version: 1.0.1-{build}
@@ -46,17 +47,18 @@
     - ps: |
         if ($env:CONFIGURATION -eq "All") {
           function bash($command) {
-            Write-Host $command -NoNewline
+            Write-Host $command
             & C:\msys64\usr\bin\bash.exe --login -c $command
             Write-Host " - OK" -ForegroundColor Green
           }
-          
+          New-Item -Force -Type Directory $env:MSYS2_CACHE
+          $unix_msys2_cache = & C:\msys64\usr\bin\bash.exe --login -c "cygpath '${env:MSYS2_CACHE}'"
           # install latest pacman
-          bash "pacman -Sy --noconfirm pacman pacman-mirrors"
+          bash "pacman -Sy --noconfirm --cache `"$unix_msys2_cache`" pacman pacman-mirrors"
           # update core packages
-          bash "pacman -Syu --noconfirm"
-          
-          bash "pacman --sync --noconfirm mingw-w64-{x86_64,i686}-toolchain mingw-w64-{x86_64,i686}-cmake"
+          bash "pacman -Syu --noconfirm --cache `"$unix_msys2_cache`""
+          # install MinGW toolchain
+          bash "pacman --sync --noconfirm --cache `"$unix_msys2_cache`" mingw-w64-{x86_64,i686}-toolchain mingw-w64-{x86_64,i686}-cmake"
         }
         
     - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@
           
           function updateCygwin($cygwinexe, $installFolder, $cacheFolder) {
             Write-Host "Update Cygwin: " $cygwinexe -NoNewline
-            & cmd /c $cygwinexe -gqnNdO -R $installFolder -s http://mirrors.kernel.org/sourceware/cygwin/ -l $cacheFolder -P mingw64-i686-gcc-g++ -P mingw64-x86_64-gcc-g++ -P gcc-g++-5.3.0-5 -P make -P cmake
+            & cmd /c $cygwinexe -gqnNdO -R $installFolder -s http://mirrors.kernel.org/sourceware/cygwin/ -l $cacheFolder -P cmake
             Write-Host " - OK" -ForegroundColor Green
           }
           

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,19 +36,19 @@
           
           function updateCygwin($cygwinexe, $installFolder, $cacheFolder) {
             Write-Host "Update Cygwin: " $cygwinexe -NoNewline
-            cmd /c start /wait $cygwinexe -gqnNdO -R $installFolder -s http://mirrors.kernel.org/sourceware/cygwin/ -l $cacheFolder -P mingw64-i686-gcc-g++ -P mingw64-x86_64-gcc-g++ -P gcc-g++-5.3.0-5 -P make -P cmake
+            & cmd /c $cygwinexe -gqnNdO -R $installFolder -s http://mirrors.kernel.org/sourceware/cygwin/ -l $cacheFolder -P mingw64-i686-gcc-g++ -P mingw64-x86_64-gcc-g++ -P gcc-g++-5.3.0-5 -P make -P cmake
             Write-Host " - OK" -ForegroundColor Green
           }
           
-          updateCygwin "setup-x86.exe" C:/cygwin $env:CYG_CACHE
-          updateCygwin "setup-x86_64.exe" C:/cygwin64 $env:CYG64_CACHE
+          updateCygwin ".\\setup-x86.exe" C:/cygwin $env:CYG_CACHE
+          updateCygwin ".\\setup-x86_64.exe" C:/cygwin64 $env:CYG64_CACHE
         }
         
     - ps: |
         if ($env:CONFIGURATION -eq "All") {
           function bash($command) {
             Write-Host $command -NoNewline
-            cmd /c start /wait C:\msys64\usr\bin\bash.exe --login -c $command
+            & C:\msys64\usr\bin\bash.exe --login -c $command
             Write-Host " - OK" -ForegroundColor Green
           }
           

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -189,7 +189,7 @@
         }
         
         Write-Host Upload Artifcat...
-        Push-AppveyorArtifact C:\projects\dokany\dokan_wix\Bootstrapper\bin\Release\DokanSetup.exe -FileName ("DokanSetup-" + $installer_version + ".exe")
+        Push-AppveyorArtifact "${env:APPVEYOR_BUILD_FOLDER}\dokan_wix\Bootstrapper\bin\Release\DokanSetup.exe" -FileName ("DokanSetup-" + $installer_version + ".exe")
         Write-Host Artifcat uploaded!
         
       } elseif ($env:CONFIGURATION -eq "FsTest") {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -250,7 +250,7 @@
   on_success:
     - ps: |
         if ($env:CONFIGURATION -eq "All") {
-            if ("$env:APPVEYOR_PULL_REQUEST_TITLE" -or "$env:APPVEYOR_REPO_BRANCH" -ne "master") {
+            if (!$env:AccessTokenDokanDoc -or "$env:APPVEYOR_PULL_REQUEST_TITLE" -or "$env:APPVEYOR_REPO_BRANCH" -ne "master") {
               return;
             }
           

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,8 @@
     AccessTokenDokanDoc:
       secure: 1JpCwgUIFUddCeF/nvSRQxb309YpVnHvN/Sd5DLRQCQPTSv/YZVv7CspelmBGSua
     global:
-      CYG_CACHE: C:\cygwin\var\cache\setup
-      CYG64_CACHE: C:\cygwin64\var\cache\setup
+      DOKAN_CI_CACHE: C:\dokan_ci_cache
+      CYG_CACHE: '%DOKAN_CI_CACHE%\cygwin'
 
   os: Visual Studio 2015
   version: 1.0.1-{build}
@@ -20,8 +20,7 @@
   - x64
   
   cache:
-  - '%CYG_CACHE%'
-  - '%CYG64_CACHE%'
+  - '%DOKAN_CI_CACHE% -> appveyor.yml'
 
   install:
     - ps: |
@@ -41,7 +40,7 @@
           }
           
           updateCygwin ".\\setup-x86.exe" C:/cygwin $env:CYG_CACHE
-          updateCygwin ".\\setup-x86_64.exe" C:/cygwin64 $env:CYG64_CACHE
+          updateCygwin ".\\setup-x86_64.exe" C:/cygwin64 $env:CYG_CACHE
         }
         
     - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,8 +32,15 @@
   
     - ps: |
         if ($env:CONFIGURATION -eq "All") {
-          wget "https://cygwin.com/setup-x86.exe" -OutFile "setup-x86.exe"
-          wget "https://cygwin.com/setup-x86_64.exe" -OutFile "setup-x86_64.exe"
+          function downloadIfOlderThanDays($url, $path, $days) {
+            if ( !(Test-Path $path -NewerThan (Get-Date).AddDays(-$days)) ) {
+              Write-Host "$path does not exist or is older than $days, downloading from $url"
+              Invoke-WebRequest $url -OutFile $path
+            }
+          }
+
+          downloadIfOlderThanDays "https://cygwin.com/setup-x86.exe" "${env:DOKAN_CI_CACHE}\setup-x86.exe" 7
+          downloadIfOlderThanDays "https://cygwin.com/setup-x86_64.exe" "${env:DOKAN_CI_CACHE}\setup-x86_64.exe" 7
           
           function updateCygwin($cygwinexe, $installFolder, $cacheFolder) {
             Write-Host "Update Cygwin: " $cygwinexe -NoNewline
@@ -41,8 +48,8 @@
             Write-Host " - OK" -ForegroundColor Green
           }
           
-          updateCygwin ".\\setup-x86.exe" C:/cygwin $env:CYG_CACHE
-          updateCygwin ".\\setup-x86_64.exe" C:/cygwin64 $env:CYG_CACHE
+          updateCygwin "${env:DOKAN_CI_CACHE}\setup-x86.exe" C:/cygwin $env:CYG_CACHE
+          updateCygwin "${env:DOKAN_CI_CACHE}\setup-x86_64.exe" C:/cygwin64 $env:CYG_CACHE
         }
         
     - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -98,10 +98,10 @@
 
       if ($env:CONFIGURATION -eq "Coverity") {
         
-        if ("$env:APPVEYOR_PULL_REQUEST_TITLE") {
+        if (!"$env:CoverityProjectToken") {
+          Add-AppveyorMessage -Message "Not running Coverity due to missing credential. Is this a fork or a pull request?" -Category Information
           return;
         }
-        
         $buildArgs = @(
         "/m",
         "/l:C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll",

--- a/build.bat
+++ b/build.bat
@@ -1,3 +1,4 @@
+@setlocal ENABLEDELAYEDEXPANSION
 REM Build release to prepare for packaging
 
 REM Make sure MSBUILD is available
@@ -7,33 +8,35 @@ IF %processor_architecture%==AMD64 set VCTargetsPath=%PROGRAMFILES(x86)%
 set VCTargetsPath=%VCTargetsPath%\MSBuild\Microsoft.Cpp\v4.0\V140
 SET failed=0
 
+REM Enable AppVeyor build message logging if running under AppVeyor
+IF "%APPVEYOR%"=="True" set CI_BUILD_ARG="/l:C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 REM Build
-msbuild dokan.sln /p:Configuration=Release /p:Platform=Win32 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration=Release /p:Platform=x64 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration="Win7 Release" /p:Platform=Win32 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration="Win7 Release" /p:Platform=x64 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration="Win8 Release" /p:Platform=Win32 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration="Win8 Release" /p:Platform=x64 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration="Win8.1 Release" /p:Platform=Win32 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration="Win8.1 Release" /p:Platform=x64 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration="Win10 Release" /p:Platform=Win32 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration="Win10 Release" /p:Platform=x64 /t:Build || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration=Release /p:Platform=Win32 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration=Release /p:Platform=x64 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration="Win7 Release" /p:Platform=Win32 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration="Win7 Release" /p:Platform=x64 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration="Win8 Release" /p:Platform=Win32 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration="Win8 Release" /p:Platform=x64 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration="Win8.1 Release" /p:Platform=Win32 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration="Win8.1 Release" /p:Platform=x64 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration="Win10 Release" /p:Platform=Win32 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration="Win10 Release" /p:Platform=x64 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
 
-msbuild dokan.sln /p:Configuration=Debug /p:Platform=Win32 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration=Debug /p:Platform=x64 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration="Win7 Debug" /p:Platform=Win32 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration="Win7 Debug" /p:Platform=x64 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration="Win8 Debug" /p:Platform=Win32 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration="Win8 Debug" /p:Platform=x64 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration="Win8.1 Debug" /p:Platform=Win32 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration="Win8.1 Debug" /p:Platform=x64 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration="Win10 Debug" /p:Platform=Win32 /t:Build || set failed=%ERRORLEVEL%
-msbuild dokan.sln /p:Configuration="Win10 Debug" /p:Platform=x64 /t:Build || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration=Debug /p:Platform=Win32 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration=Debug /p:Platform=x64 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration="Win7 Debug" /p:Platform=Win32 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration="Win7 Debug" /p:Platform=x64 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration="Win8 Debug" /p:Platform=Win32 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration="Win8 Debug" /p:Platform=x64 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration="Win8.1 Debug" /p:Platform=Win32 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration="Win8.1 Debug" /p:Platform=x64 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration="Win10 Debug" /p:Platform=Win32 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
+msbuild dokan.sln /p:Configuration="Win10 Debug" /p:Platform=x64 /t:Build !CI_BUILD_ARG! || set failed=%ERRORLEVEL%
 
 IF EXIST C:\cygwin ( Powershell.exe -executionpolicy remotesigned -File dokan_fuse/build.ps1 || set failed=%ERRORLEVEL% ) ELSE ( echo "Cygwin/Msys2 build disabled" )
 
-@if %failed% neq 0 (
-    echo At least one build-command failed. The last command that failed returned with error %failed% 1>&2
-    exit /b %failed%
+@if !failed! neq 0 (
+    echo At least one build-command failed. The last command that failed returned with error !failed! 1>&2
+    exit /b !failed!
 )
 

--- a/dokan_fuse/build.ps1
+++ b/dokan_fuse/build.ps1
@@ -7,7 +7,7 @@ $script:failed = 0
     & C:\cygwin\bin\bash -lc "
         cd '$currentPath'/'$buildDir' &&
         cmake ../../../ -DCMAKE_INSTALL_PREFIX='../../../../$installDir' -DCMAKE_INSTALL_BINDIR=. &&
-        make install"
+        make -j `$(getconf _NPROCESSORS_ONLN) install"
     & C:\cygwin\bin\bash -lc "
         cd '$currentPath' &&
         gcc -o '$installDir'/mirror samples/fuse_mirror/fusexmp.c -I '$installDir/include' -D_FILE_OFFSET_BITS=64 -L $installDir/ -lcygdokanfuse1"
@@ -22,7 +22,7 @@ $script:failed = 0
     & C:\cygwin64\bin\bash -lc "
         cd '$currentPath'/'$buildDir' &&
         cmake ../../../ -DCMAKE_INSTALL_PREFIX='../../../../$installDir' -DCMAKE_INSTALL_BINDIR=. &&
-        make install"
+        make -j `$(getconf _NPROCESSORS_ONLN) install"
     & C:\cygwin64\bin\bash -lc "
         cd '$currentPath' &&
         gcc -o '$installDir'/mirror samples/fuse_mirror/fusexmp.c -I '$installDir/include' -D_FILE_OFFSET_BITS=64 -L $installDir/ -lcygdokanfuse1"
@@ -38,7 +38,7 @@ $script:failed = 0
     & C:\msys64\usr\bin\bash -lc "
         cd '$currentPath'/'$buildDir' &&
         cmake ../../../ -DCMAKE_INSTALL_PREFIX='../../../../$installDir' -DCMAKE_INSTALL_BINDIR=. -G 'MSYS Makefiles' &&
-        make install"
+        make -j `$(getconf _NPROCESSORS_ONLN) install"
     }
     Remove-Item Env:\MSYSTEM
     if ($LASTEXITCODE -ne 0) {
@@ -52,7 +52,7 @@ $script:failed = 0
     & C:\msys64\usr\bin\bash -lc "
         cd '$currentPath'/'$buildDir' &&
         cmake ../../../ -DCMAKE_INSTALL_PREFIX='../../../../$installDir' -DCMAKE_INSTALL_BINDIR=. -G 'MSYS Makefiles' &&
-        make install"
+        make -j `$(getconf _NPROCESSORS_ONLN) install"
     Remove-Item Env:\MSYSTEM
     if ($LASTEXITCODE -ne 0) {
         $script:failed = $LASTEXITCODE


### PR DESCRIPTION
This set of commits fixes a few issues and decreases the time needed for a build.

Issues:
* command output was not appearing in log
* documentation push and Coverity Scan were run when using AppVeyor in one's private fork
* MSBuild output was not appearing in Messages tab in AppVeyor

The other part of the patches are some speed-ups. We cache downloaded packages to reduce load on the mirrors and decrease build-times. The individual speed-ups are not very big for some of the commits, because the cache is downloaded as a zip-archive at the beginning of the build as well and it does not matter which server you download from. There are some improvements underway from the AppVeyor side, so this might get faster in the future. Download-locations can be flaky though, so even without huge speed-ups  the cache should improve things. For example I have seen the Cygwin-Setup-download taking longer sometimes. Should any problems arise, can we move individual dirs out of the cache using environment variables at the top.
For a closer analysis, one can hover over the line numbers in the AppVeyor build-output to see when each line was printed. Though one needs to build at least one commit where `appveyor.yml` is not modified to see the cache in effect.
