### PR TITLE
CI: Temporary fix for bug in MSYS2-MINGW-CMake

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -96,6 +96,8 @@
           bash "pacman -Syu --noconfirm --cache `"$unix_msys2_cache`""
           # install MinGW toolchain
           bash "pacman --sync --noconfirm --cache `"$unix_msys2_cache`" mingw-w64-{x86_64,i686}-toolchain mingw-w64-{x86_64,i686}-cmake"
+          # temporary workaround for bug https://github.com/Alexpux/MINGW-packages/issues/1991
+          bash "pacman -S --noconfirm --cache `"$unix_msys2_cache`" mingw-w64-{x86_64,i686}-libxml2"
         }
 
   before_build:


### PR DESCRIPTION
The MSYS2-MINGW-CMake packaging (or one of its dependencies is missing a dependency
to libxml2) This breaks our build, see: https://ci.appveyor.com/project/Maxhy/dokany/build/1.0.1-27/job/ova2o24yyjh9i009#L4739.

How I troubleshooted this:
The error-message with libuv is a red herring. Nothing is wrong with libuv from what I can see and on my system stderr complains about zlib instead of libuv as it does on AppVeyor (both are installed). Running the executable from the GUI will produce the correct error message as a MessageBox.

This commit can be reverted once the bug is fixed:
Alexpux/MINGW-packages#1991
