### PR TITLE
Fix deadlock in DokanDispatchCleanup().

### DIFF
--- a/sys/cleanup.c
+++ b/sys/cleanup.c
@@ -88,9 +88,11 @@ Return Value:
 
     if (fileObject->SectionObjectPointer != NULL &&
         fileObject->SectionObjectPointer->DataSectionObject != NULL) {
+      ExAcquireResourceExclusiveLite(&fcb->PagingIoResource, TRUE);
       CcFlushCache(&fcb->SectionObjectPointers, NULL, 0, NULL);
       CcPurgeCacheSection(&fcb->SectionObjectPointers, NULL, 0, FALSE);
       CcUninitializeCacheMap(fileObject, NULL, NULL);
+      ExReleaseResourceLite(&fcb->PagingIoResource);
     }
 
     DokanFCBLockRW(fcb);


### PR DESCRIPTION
DokanDispatchCleanup() was calling CcFlushCache() without acquiring the
PagingIoResource exclusive lock. This was allowing concurrent calls to
CcFlushCache(), via e.g. DokanDispatchRead() and DokanDispatchClose(), for the
same file control block ultimately leading to a deadlock in CcFlushCache().

Please see below a dump of my windbg session for more concrete evidence:
2: kd> !locks
**** DUMP OF ALL RESOURCE OBJECTS ****
KD: Scanning for held locks...........

Resource @ 0xffffaa05cc7b46c0    Exclusively owned
    Contention Count = 2
    NumberOfSharedWaiters = 1
    NumberOfExclusiveWaiters = 1
     Threads: ffffaa05ca9df7c0-01<*> ffffaa05c93fc080-01
     Threads Waiting On Exclusive Access:
              ffffaa05c93fe080

Resource @ 0xffffaa05c9626400    Exclusively owned
    Contention Count = 2
    NumberOfSharedWaiters = 1
    NumberOfExclusiveWaiters = 1
     Threads: ffffaa05c93fc080-01<*> ffffaa05cabbe080-01
     Threads Waiting On Exclusive Access:
              ffffaa05ca9df7c0

KD: Scanning for held locks........
16088 total locks, 2 locks currently held

2: kd> .thread ffffaa05ca9df7c0
Implicit thread is now ffffaa05`ca9df7c0

2: kd> kn
  *** Stack trace for last set context - .thread/.cxr resets it
 # Child-SP          RetAddr           Call Site
00 ffffbb81`16522e40 fffff802`b1ac4cdc nt!KiSwapContext+0x76
01 ffffbb81`16522f80 fffff802`b1ac477f nt!KiSwapThread+0x17c
02 ffffbb81`16523030 fffff802`b1ac6a28 nt!KiCommitThreadWait+0x14f
03 ffffbb81`165230d0 fffff802`b1ad1043 nt!ExpWaitForResource+0x2a8
04 ffffbb81`165231a0 fffff802`b1f02273 nt!ExAcquireResourceExclusiveLite+0x183
05 ffffbb81`16523220 fffff802`b1b144da nt!FsRtlAcquireFileForCcFlushEx+0x27f
06 ffffbb81`165234d0 fffff802`b1ae4896 nt!MmFlushSection+0x9e
07 ffffbb81`16523580 fffff802`b1b6f67e nt!CcFlushCachePriv+0x616
08 ffffbb81`16523690 fffff80f`ac9b831e nt!CcFlushCache+0x16
09 ffffbb81`165236d0 fffff80f`ac9b35bc fs1!DokanDispatchRead+0x1ee
0a ffffbb81`16523770 fffff80f`ac9b342b fs1!DokanDispatchRequest+0x120
0b ffffbb81`165237a0 fffff80f`ab405206 fs1!DokanBuildRequest+0x47
0c ffffbb81`165237f0 fffff80f`ab403146 FLTMGR!FltpLegacyProcessingAfterPr...
0d ffffbb81`16523880 fffff802`b1e8ba20 FLTMGR!FltpDispatch+0xb6
0e ffffbb81`165238e0 fffff802`b1e8a020 nt!IopSynchronousServiceTail+0x1a0
0f ffffbb81`165239a0 fffff802`b1bdfc93 nt!NtReadFile+0x660
10 ffffbb81`16523a90 00007ffa`a9094f14 nt!KiSystemServiceCopyEnd+0x13
11 00000000`06d1ec88 00000000`00000000 0x00007ffa`a9094f14

2: kd> .frame 0n9;dv /t /v
09 ffffbb81`165236d0 fffff80f`ac9b35bc fs1!DokanDispatchRead+0x1ee
ffffbb81`16523710 struct _DokanFileControlBlock * fcb = 0xffffaa05`cc7b4600

2: kd> .thread ffffaa05c93fc080
Implicit thread is now ffffaa05`c93fc080
2: kd> kn
  *** Stack trace for last set context - .thread/.cxr resets it
 # Child-SP          RetAddr           Call Site
00 ffffbb81`1645ae50 fffff802`b1ac4cdc nt!KiSwapContext+0x76
01 ffffbb81`1645af90 fffff802`b1ac477f nt!KiSwapThread+0x17c
02 ffffbb81`1645b040 fffff802`b1ac6a28 nt!KiCommitThreadWait+0x14f
03 ffffbb81`1645b0e0 fffff802`b1ad1595 nt!ExpWaitForResource+0x2a8
04 ffffbb81`1645b1b0 fffff802`b1f02244 nt!ExAcquireResourceSharedLite+0x325
05 ffffbb81`1645b240 fffff802`b1b144da nt!FsRtlAcquireFileForCcFlushEx+0x250
06 ffffbb81`1645b4f0 fffff802`b1ae4896 nt!MmFlushSection+0x9e
07 ffffbb81`1645b5a0 fffff802`b1b6f67e nt!CcFlushCachePriv+0x616
08 ffffbb81`1645b6b0 fffff80f`ac9b12f9 nt!CcFlushCache+0x16
09 ffffbb81`1645b6f0 fffff80f`ac9b3659 fs1!DokanDispatchCleanup+0x99
0a ffffbb81`1645b760 fffff80f`ac9b342b fs1!DokanDispatchRequest+0x1bd
0b ffffbb81`1645b790 fffff80f`ab405206 fs1!DokanBuildRequest+0x47
0c ffffbb81`1645b7e0 fffff80f`ab403146 FLTMGR!FltpLegacyProcessingAfterPr...
0d ffffbb81`1645b870 fffff802`b1eafc80 FLTMGR!FltpDispatch+0xb6
0e ffffbb81`1645b8d0 fffff802`b1e96719 nt!IopCloseFile+0x150
0f ffffbb81`1645b960 fffff802`b1ee719b nt!ObCloseHandleTableEntry+0x249
10 ffffbb81`1645baa0 fffff802`b1bdfc93 nt!NtClose+0xcb
11 ffffbb81`1645bb00 00007ffa`a9095034 nt!KiSystemServiceCopyEnd+0x13
12 00000000`08ceeef8 00000000`00000000 0x00007ffa`a9095034
2: kd> .frame 0n9;dv /t /v
09 ffffbb81`1645b6f0 fffff80f`ac9b3659 fs1!DokanDispatchCleanup+0x99
@r15              struct _DokanFileControlBlock * fcb = 0xffffaa05`cc7b4600