### PR TITLE
CI: Don't write clang-format diff if no changes in C-files

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -264,8 +264,8 @@
           $prBranchHead = $parents[2]
 
           $diffFile = "clang_format_$(& git rev-parse --short $prBranchHead)_into_$(& git rev-parse --short $mergeBranchHead).diff"
-          Exec-External {& git clang-format --style=file --diff $mergeBranchHead} |
-            Select-String -NotMatch "^clang-format did not modify any files$" > $diffFile
+          Exec-External {& git clang-format --quiet --style=file --diff $mergeBranchHead} |
+            Select-String -NotMatch "^no modified files to format$" > $diffFile
           if ((Get-Item $diffFile).length -gt 0) {
             Write-Host "Ran git clang-format on PR, found changes, uploading as artifact"
             Add-AppveyorMessage `


### PR DESCRIPTION
This fixes a small issue where the script did not account for the case where
no C-files where modified in a PR and git-clang-format wrote a
.diff-file with the text "no modified files to format".

[Example-PR where it occurred](https://ci.appveyor.com/project/Maxhy/dokany/build/1.0.1-62/job/v9r38yu1ciowoqm6/messages)

Ideally clang-format would print messages like this to stderr. As a
workaround we are grepping for the message to filter it out.