### PR TITLE
Fix use-after-free in GetDokanOpenInfo().

### DIFF
--- a/dokan/create.c
+++ b/dokan/create.c
@@ -330,9 +330,11 @@ VOID DispatchCreate(HANDLE Handle, // This handle is not for a file. It is for
   if (origFileName)
     free(origFileName);
 
+  if (eventInfo.Status != STATUS_SUCCESS) {
+    free((PDOKAN_OPEN_INFO)(UINT_PTR)eventInfo.Context);
+    eventInfo.Context = 0;
+  }
+
   SendEventInformation(Handle, &eventInfo, sizeof(EVENT_INFORMATION),
                        DokanInstance);
-
-  if (eventInfo.Status != STATUS_SUCCESS)
-    free((PDOKAN_OPEN_INFO)(UINT_PTR)eventInfo.Context);
 }


### PR DESCRIPTION
The DOKAN_OPEN_INFO struct is ref-counted in userspace while an opaque pointer
to it is also stored, though not dereferenced, in kernel space via the
EVENT_CONTEXT struct.

Ref-counting is needed to manage the lifetime of DOKAN_OPEN_INFO as Dokan uses
loosely synchronized worker threads in userspace to dispatch the actual file
system requests.

When the ref-count of the DOKAN_OPEN_INFO goes to 0, the DOKAN_OPEN_INFO
pointer gets free'd. However worker threads other than the thread doing the
free() could still observe a stale copy of the pointer in their EVENT_CONTEXT
struct which each worker thread has a unique instance of.

This changes the user-space library so that there is an extra indirection to
lookup DOKAN_OPEN_INFO pointers. Instead of directly dereferencing a
potentially stale DOKAN_OPEN_INFO pointer, GetDokanOpenInfo() now looks up the
pointer in a table of entries indexed by a monotonically increasing ID which is
also stored in the EVENT_CONTEXT struct.

See issue 436 for more details.