### PR TITLE
Remove ref-counting of DOKAN_OPEN_INFO pointers.

### DIFF
--- a/dokan/access.c
+++ b/dokan/access.c
@@ -38,7 +38,7 @@ HANDLE DOKANAPI DokanOpenRequestorToken(PDOKAN_FILE_INFO FileInfo) {
     return INVALID_HANDLE_VALUE;
   }
 
-  eventContext = openInfo->EventContext;
+  eventContext = FileInfo->EventContext;
   if (eventContext == NULL) {
     return INVALID_HANDLE_VALUE;
   }

--- a/dokan/close.c
+++ b/dokan/close.c
@@ -49,10 +49,8 @@ VOID DispatchClose(HANDLE Handle, PEVENT_CONTEXT EventContext,
   // SendEventInformation(Handle, eventInfo, length);
 
   if (openInfo != NULL) {
-    EnterCriticalSection(&DokanInstance->CriticalSection);
-    openInfo->OpenCount--;
-    LeaveCriticalSection(&DokanInstance->CriticalSection);
+    ReleaseDokanOpenInfo(openInfo, DokanInstance);
+    eventInfo->Context = 0;
   }
-  ReleaseDokanOpenInfo(eventInfo, DokanInstance);
   free(eventInfo);
 }

--- a/dokan/create.c
+++ b/dokan/create.c
@@ -122,6 +122,7 @@ VOID DispatchCreate(HANDLE Handle, // This handle is not for a file. It is for
   eventInfo.BufferLength = 0;
   eventInfo.SerialNumber = EventContext->SerialNumber;
 
+  fileInfo.EventContext = EventContext;
   fileInfo.ProcessId = EventContext->ProcessId;
   fileInfo.DokanOptions = DokanInstance->DokanOptions;
 
@@ -134,8 +135,6 @@ VOID DispatchCreate(HANDLE Handle, // This handle is not for a file. It is for
     return;
   }
   ZeroMemory(openInfo, sizeof(DOKAN_OPEN_INFO));
-  openInfo->OpenCount = 2;
-  openInfo->EventContext = EventContext;
   openInfo->DokanInstance = DokanInstance;
   fileInfo.DokanContext = (ULONG64)openInfo;
 

--- a/dokan/dokan.h
+++ b/dokan/dokan.h
@@ -158,6 +158,8 @@ typedef struct _DOKAN_FILE_INFO {
   UCHAR Nocache;
   /**  If \c TRUE, write to the current end of file instead of using the Offset parameter. */
   UCHAR WriteToEndOfFile;
+  /** EventContext for the current operation being dispatched. */
+  PEVENT_CONTEXT EventContext;
 } DOKAN_FILE_INFO, *PDOKAN_FILE_INFO;
 
 /**

--- a/dokan/dokani.h
+++ b/dokan/dokani.h
@@ -81,10 +81,6 @@ typedef struct _DOKAN_INSTANCE {
 typedef struct _DOKAN_OPEN_INFO {
   /** DOKAN_OPTIONS linked to the mount */
   BOOL IsDirectory;
-  /** Open count on the file */
-  ULONG OpenCount;
-  /** Event context */
-  PEVENT_CONTEXT EventContext;
   /** Dokan instance linked to the open */
   PDOKAN_INSTANCE DokanInstance;
   /** User Context see DOKAN_FILE_INFO.Context */
@@ -190,10 +186,7 @@ VOID ClearFindStreamData(PLIST_ENTRY ListHead);
 
 UINT WINAPI DokanKeepAlive(PVOID Param);
 
-PDOKAN_OPEN_INFO
-GetDokanOpenInfo(PEVENT_CONTEXT EventInfomation, PDOKAN_INSTANCE DokanInstance);
-
-VOID ReleaseDokanOpenInfo(PEVENT_INFORMATION EventInfomation,
+VOID ReleaseDokanOpenInfo(PDOKAN_OPEN_INFO OpenInfo,
                           PDOKAN_INSTANCE DokanInstance);
 
 #ifdef __cplusplus

--- a/dokan/timeout.c
+++ b/dokan/timeout.c
@@ -38,7 +38,7 @@ BOOL DOKANAPI DokanResetTimeout(ULONG Timeout, PDOKAN_FILE_INFO FileInfo) {
     return FALSE;
   }
 
-  eventContext = openInfo->EventContext;
+  eventContext = FileInfo->EventContext;
   if (eventContext == NULL) {
     return FALSE;
   }

--- a/dokan/volume.c
+++ b/dokan/volume.c
@@ -332,6 +332,7 @@ VOID DispatchQueryVolumeInformation(HANDLE Handle, PEVENT_CONTEXT EventContext,
   eventInfo->BufferLength = 0;
   eventInfo->SerialNumber = EventContext->SerialNumber;
 
+  fileInfo.EventContext = EventContext;
   fileInfo.ProcessId = EventContext->ProcessId;
   fileInfo.DokanOptions = DokanInstance->DokanOptions;
 


### PR DESCRIPTION
DispatchClose() is guaranteed to be called once all the outstanding
operations for the handle completed so ref-counting doesn't appear to be
necessary.