### PR TITLE
Add DokanFreeMdl for read operation

### DIFF
--- a/sys/read.c
+++ b/sys/read.c
@@ -329,6 +329,11 @@ VOID DokanCompleteRead(__in PIRP_ENTRY IrpEntry,
     }
   }
 
+  if (IrpEntry->Flags & DOKAN_MDL_ALLOCATED) {
+	  DokanFreeMdl(irp);
+	  IrpEntry->Flags &= ~DOKAN_MDL_ALLOCATED;
+  }
+
   if (NT_SUCCESS(status)) {
     DDbgPrint("  STATUS_SUCCESS\n");
   } else if (status == STATUS_INSUFFICIENT_RESOURCES) {


### PR DESCRIPTION
Forgotten free MDL in DokanCompleteRead. Add the DokanFreeMdl to fix. Fix for #442 .

I think this time should be correct. Please correct me if I messed up again.