### PR TITLE
Check event info status in DispatchCreate() with NT_SUCCESS() as in t…

### DIFF
--- a/dokan/create.c
+++ b/dokan/create.c
@@ -330,7 +330,7 @@ VOID DispatchCreate(HANDLE Handle, // This handle is not for a file. It is for
   if (origFileName)
     free(origFileName);
 
-  if (eventInfo.Status != STATUS_SUCCESS) {
+  if (!NT_SUCCESS(eventInfo.Status)) {
     free((PDOKAN_OPEN_INFO)(UINT_PTR)eventInfo.Context);
     eventInfo.Context = 0;
   }

--- a/dokan/dokanc.h
+++ b/dokan/dokanc.h
@@ -124,6 +124,8 @@ static VOID DokanDbgPrintW(LPCWSTR format, ...) {
 
 #endif // MSVC
 
+#define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
+
 VOID DOKANAPI DokanUseStdErr(BOOL Status);
 
 VOID DOKANAPI DokanDebugMode(BOOL Status);


### PR DESCRIPTION
…he driver.

DokanCompleteCreate() in the driver uses the NT_SUCCESS() macro to check
whether it should free the CCB, FCB... while DispatchCreate() in
userspace was freeing the DOKAN_OPEN_INFO pointer when the event info
status was not equal to STATUS_SUCCESS.

This was leading to operations being sent to userspace with a null
DOKAN_OPEN_INFO pointer after DispatchCreate() returned a successful
non-STATUS_SUCCESS status such as STATUS_TIMEOUT.