### PR TITLE
Fix crash issue cause by canceling the copy operation

### DIFF
--- a/sys/event.c
+++ b/sys/event.c
@@ -779,5 +779,8 @@ DokanEventWrite(__in PDEVICE_OBJECT DeviceObject, _Inout_ PIRP Irp) {
 
   KeReleaseSpinLock(&vcb->Dcb->PendingIrp.ListLock, oldIrql);
 
-  return STATUS_SUCCESS;
+  // if the corresponding IRP not found, the user should already canceled the operation and the IRP already destoryed.
+  DDbgPrint("  EventWrite : Cannot found corresponding IRP. User should already canceled the operation. Return STATUS_CANCELLED.");
+
+  return STATUS_CANCELLED;
 }


### PR DESCRIPTION
The root cause is because the dokan.sys will still return status_success when the corresponding IRP is not found cause by the user cancellation. With this fix, the driver will return status_cancelled and the dokan usermode dll will handle the status returned correctly. This fix will fix the issue #447 .