### PR TITLE
Fix crash issue cause by canceling the copy operation

### DIFF
--- a/dokan/write.c
+++ b/dokan/write.c
@@ -21,8 +21,10 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 
 #include "dokani.h"
 
-VOID SendWriteRequest(HANDLE Handle, PEVENT_INFORMATION EventInfo,
-                      ULONG EventLength, PVOID Buffer, ULONG BufferLength) {
+BOOL SendWriteRequest(_In_ HANDLE Handle, _In_ PEVENT_INFORMATION EventInfo,
+                      _In_ ULONG EventLength, _Out_ PVOID Buffer, _In_ ULONG BufferLength, 
+                      _Out_ ULONG *ReturnedLengthOutPointer, _Out_ DWORD *LastError) {
+
   BOOL status;
   ULONG returnedLength;
 
@@ -41,9 +43,17 @@ VOID SendWriteRequest(HANDLE Handle, PEVENT_INFORMATION EventInfo,
   if (!status) {
     DWORD errorCode = GetLastError();
     DbgPrint("Ioctl failed with code %d\n", errorCode);
+	*LastError = errorCode;
+  }
+  else {
+	*LastError = 0;
   }
 
+  *ReturnedLengthOutPointer = returnedLength;
+
   DbgPrint("SendWriteRequest got %d bytes\n", returnedLength);
+
+  return status;
 }
 
 VOID DispatchWrite(HANDLE Handle, PEVENT_CONTEXT EventContext,
@@ -55,6 +65,9 @@ VOID DispatchWrite(HANDLE Handle, PEVENT_CONTEXT EventContext,
   DOKAN_FILE_INFO fileInfo;
   BOOL bufferAllocated = FALSE;
   ULONG sizeOfEventInfo = sizeof(EVENT_INFORMATION);
+  ULONG returnedLength = 0;
+  BOOL SendWriteRequestStatus = TRUE;	// otherwise DokanInstance->DokanOperations->WriteFile cannot be called
+  DWORD SendWriteRequestLastError = 0;
 
   eventInfo = DispatchCommon(EventContext, sizeOfEventInfo, DokanInstance,
                              &fileInfo, &openInfo);
@@ -68,8 +81,9 @@ VOID DispatchWrite(HANDLE Handle, PEVENT_CONTEXT EventContext,
       free(eventInfo);
       return;
     }
-    SendWriteRequest(Handle, eventInfo, sizeOfEventInfo, contextBuf,
-                     contextLength);
+
+	SendWriteRequestStatus = SendWriteRequest(Handle, eventInfo, sizeOfEventInfo, contextBuf,
+                     contextLength, &returnedLength, &SendWriteRequestLastError);
     EventContext = contextBuf;
     bufferAllocated = TRUE;
   }
@@ -78,14 +92,28 @@ VOID DispatchWrite(HANDLE Handle, PEVENT_CONTEXT EventContext,
 
   DbgPrint("###WriteFile %04d\n", openInfo != NULL ? openInfo->EventId : -1);
 
-  if (DokanInstance->DokanOperations->WriteFile) {
-    status = DokanInstance->DokanOperations->WriteFile(
-        EventContext->Operation.Write.FileName,
-        (PCHAR)EventContext + EventContext->Operation.Write.BufferOffset,
-        EventContext->Operation.Write.BufferLength, &writtenLength,
-        EventContext->Operation.Write.ByteOffset.QuadPart, &fileInfo);
-  } else {
-    status = STATUS_NOT_IMPLEMENTED;
+  if (!SendWriteRequestStatus) {
+	  if (SendWriteRequestLastError == ERROR_OPERATION_ABORTED) {
+		  status = STATUS_CANCELLED;
+		  DbgPrint("WriteFile Error : User should already canceled the operation. Return STATUS_CANCELLED. \n");
+	  }
+	  else {
+		  status = DokanNtStatusFromWin32(SendWriteRequestLastError);
+		  DbgPrint("Unknown SendWriteRequest Error : LastError from SendWriteRequest = %lu. \nUnknown SendWriteRequest error : EventContext had been destoryed. Status = %X. \n", SendWriteRequestLastError, status);
+	  }
+  }
+  else {
+	  // for the case SendWriteRequest success
+	  if (DokanInstance->DokanOperations->WriteFile) {
+		  status = DokanInstance->DokanOperations->WriteFile(
+			  EventContext->Operation.Write.FileName,
+			  (PCHAR)EventContext + EventContext->Operation.Write.BufferOffset,
+			  EventContext->Operation.Write.BufferLength, &writtenLength,
+			  EventContext->Operation.Write.ByteOffset.QuadPart, &fileInfo);
+	  }
+	  else {
+		  status = STATUS_NOT_IMPLEMENTED;
+	  }
   }
 
   if (openInfo != NULL)

--- a/sys/event.c
+++ b/sys/event.c
@@ -779,5 +779,8 @@ DokanEventWrite(__in PDEVICE_OBJECT DeviceObject, _Inout_ PIRP Irp) {
 
   KeReleaseSpinLock(&vcb->Dcb->PendingIrp.ListLock, oldIrql);
 
-  return STATUS_SUCCESS;
+  // if the corresponding IRP not found, the user should already canceled the operation and the IRP already destroyed.
+  DDbgPrint("  EventWrite : Cannot found corresponding IRP. User should already canceled the operation. Return STATUS_CANCELLED.");
+
+  return STATUS_CANCELLED;
 }


### PR DESCRIPTION
The root cause is because the dokan.sys will still return status_success when the corresponding IRP is not found cause by the user cancellation. With this fix, the driver will return status_cancelled and the dokan usermode dll will handle the status returned correctly. This fix will fix the issue #447 .

Sorry for the typo in the previous pull request.