### PR TITLE
Use filename check before doing flush. Remove code redudancy

### DIFF
--- a/sys/cleanup.c
+++ b/sys/cleanup.c
@@ -86,22 +86,7 @@ Return Value:
     fcb = ccb->Fcb;
     ASSERT(fcb != NULL);
 
-    if (fileObject->SectionObjectPointer != NULL) {
-
-      if (fileObject->SectionObjectPointer->ImageSectionObject != NULL) {
-        MmFlushImageSection(&fcb->SectionObjectPointers, MmFlushForWrite);
-        DDbgPrint("  MmFlushImageSection executed\n");
-      }
-
-      if (fileObject->SectionObjectPointer->DataSectionObject != NULL) {
-        ExAcquireResourceExclusiveLite(&fcb->PagingIoResource, TRUE);
-        CcFlushCache(&fcb->SectionObjectPointers, NULL, 0, NULL);
-        CcPurgeCacheSection(&fcb->SectionObjectPointers, NULL, 0, FALSE);
-        CcUninitializeCacheMap(fileObject, NULL, NULL);
-        ExReleaseResourceLite(&fcb->PagingIoResource);
-        DDbgPrint("  CcUninitializeCacheMap executed\n");
-      }
-    }
+    FlushFcb(fcb, fileObject);
     
     DokanFCBLockRW(fcb);
 

--- a/sys/create.c
+++ b/sys/create.c
@@ -537,23 +537,12 @@ Return Value:
         DDbgPrint("  Verify if the system tries to access System Volume\n");
         UNICODE_STRING systemVolume;
         RtlInitUnicodeString(&systemVolume, L"\\System Volume Information");
-        if (fileObject->FileName.Length >= systemVolume.Length) {
-          LPCWSTR p1, p2;
-          p1 = systemVolume.Buffer;
-          p2 = fileObject->FileName.Buffer;
-          unsigned int len = 0;
-          LONG ret = 0;
-          while (!ret && len < 26) {
-            ret = *p1++ - *p2++;
-            ++len;
-          }
-          if (ret == 0 && (systemVolume.Length == fileObject->FileName.Length ||
-                           *p2 == L'\\')) {
-            DDbgPrint("  It's an access to System Volume, so don't return "
-                      "SUCCESS. We don't have one.\n");
-            status = STATUS_NO_SUCH_FILE;
-            __leave;
-          }
+        BOOLEAN isSystemVolumeAccess = StartsWith(&fileObject->FileName, &systemVolume);
+        if (isSystemVolumeAccess) {
+          DDbgPrint("  It's an access to System Volume, so don't return "
+                    "SUCCESS. We don't have one.\n");
+          status = STATUS_NO_SUCH_FILE;
+          __leave;
         }
       }
       status = STATUS_SUCCESS;

--- a/sys/dokan.h
+++ b/sys/dokan.h
@@ -699,6 +699,9 @@ PointerAlignSize(ULONG sizeInBytes);
 VOID DokanCreateMountPoint(__in PDokanDCB Dcb);
 NTSTATUS DokanSendVolumeArrivalNotification(PUNICODE_STRING DeviceName);
 
+VOID FlushFcb(__in PDokanFCB fcb, __in_opt PFILE_OBJECT fileObject);
+BOOLEAN StartsWith(__in PUNICODE_STRING str, __in PUNICODE_STRING prefix);
+
 static UNICODE_STRING sddl = RTL_CONSTANT_STRING(
     L"D:P(A;;GA;;;SY)(A;;GRGWGX;;;BA)(A;;GRGWGX;;;WD)(A;;GRGX;;;RC)");
 


### PR DESCRIPTION
The check of the filename is now implemented. It's suboptimal because the backslash should be added to the folder before the check is performed. This is not possible without allocation of additional memory. Anyway the changes improve the code a lot and code redundancy is eliminated.