### PR TITLE
CI: Try rebooting two times and reduce timeout

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,13 @@
           Write-Host "Before reboot"
           Start-Sleep -s 2
           Restart-Computer
-          Start-Sleep -s 3600 # will reboot before this is finished and proceed with next build step
+          Start-Sleep -s 240 # will reboot before this is finished and proceed with next build step
+          Write-Host "Did not reboot for some reason, trying Restart-Computer -Force"
+          Start-Sleep -s 2
+          Restart-Computer -Force
+          Start-Sleep -s 240
+          Write-Host "Still has not rebooted"
+          throw ("Tried rebooting two times, failed")
         }
     - ps: |
         function Exec-External {


### PR DESCRIPTION
Turns out that waiting for 60mins was not so smart... 😊 

Using the changes below, builds should fail early and we can find out, whether the build-VM does not shut down or whether it does not come back after reboot.

Instead of waiting for an hour to reboot, try rebooting in two different
ways with a timeout of 4 minutes each. If the system has not rebooted
after those two tries, fail the build.