### PR TITLE
FUSE: Check for non-empty directories on delete

### DIFF
--- a/dokan_fuse/include/fusemain.h
+++ b/dokan_fuse/include/fusemain.h
@@ -116,6 +116,11 @@ public:
 		const struct FUSE_STAT *stbuf, FUSE_OFF_T off);
 	static int walk_directory_getdir(fuse_dirh_t hndl, const char *name, int type,ino_t ino);
 
+	static int readdir_filler_set_has_files(void *buf, const char *name,
+		const struct FUSE_STAT *stbuf, FUSE_OFF_T off);
+	static int getdir_filler_set_has_files(fuse_dirh_t hndl, const char *name,
+		int type, ino_t ino);
+
 	///////////////////////////////////Delegates//////////////////////////////
 	int find_files(LPCWSTR file_name, PFillFindData fill_find_data,
 		PDOKAN_FILE_INFO dokan_file_info);


### PR DESCRIPTION
Fixes #270.

Two remaining questions before merging. The first one is more out of interest, the second one is more relevant to this PR.
1. @Liryna As you can see I put the check earlier than you suggested in #270, which is in line with [what I read about file-deletion on Windows](http://download.microsoft.com/download/4/3/8/43889780-8d45-4b2e-9d3a-c696a890309f/File%20System%20Behavior%20Overview.pdf). This is a general question about Windows: What happens when the deletion fails during cleanup? Is it true that there is no possibility to signal user space that a deletion failed?
2. Is there the possibility of race conditions?
    * FileSetDisposition is called
    * the DeleteDirectory callback enumerates the direntries, finds none
    * a file is placed into the directory
    * DeleteDirectory returns with no-error (because it was empty), signals that the directory is going to be deleted
