### PR TITLE
Ensure fuse context is set during walk directory

### DIFF
--- a/dokan_fuse/include/fusemain.h
+++ b/dokan_fuse/include/fusemain.h
@@ -104,12 +104,17 @@ public:
 	int resolve_symlink(const std::string &name, std::string *res);
 	int check_and_resolve(std::string *name);
 
+    typedef int(*PWalkDirectoryWithSetFuseContext)(PDOKAN_FILE_INFO DokanFileInfo, void *buf, const char *name,
+        const struct FUSE_STAT *stbuf,
+        FUSE_OFF_T off);
+
 	struct walk_data
 	{
 		impl_fuse_context *ctx;
 		std::string dirname;
 		PDOKAN_FILE_INFO DokanFileInfo;
 		PFillFindData delegate;
+        PWalkDirectoryWithSetFuseContext delegateSetFuseContext;
 		std::vector<std::string> getdir_data; //Used only in walk_directory_getdir()
 	};
 	static int walk_directory(void *buf, const char *name,
@@ -118,6 +123,7 @@ public:
 
 	///////////////////////////////////Delegates//////////////////////////////
 	int find_files(LPCWSTR file_name, PFillFindData fill_find_data,
+        PWalkDirectoryWithSetFuseContext walk_set_fuse_context,
 		PDOKAN_FILE_INFO dokan_file_info);
 
 	int open_directory(LPCWSTR file_name, PDOKAN_FILE_INFO dokan_file_info);


### PR DESCRIPTION
When fuse bindings calls the filler which is the dokans walk_directory method. The walk_directory is called on different thread. We need to ensure that even then the fuse context is set. This fixes one part of the issue https://github.com/dokan-dev/dokany/issues/465. The other changes are inside of fuse-bindings required.