### PR TITLE
MirrorCreateFile - Return the correct error code when trying to open a directory as file.

### DIFF
--- a/samples/dokan_mirror/mirror.c
+++ b/samples/dokan_mirror/mirror.c
@@ -366,6 +366,14 @@ MirrorCreateFile(LPCWSTR FileName, PDOKAN_IO_SECURITY_CONTEXT SecurityContext,
         CreateDisposition == FILE_CREATE)
       return STATUS_OBJECT_NAME_COLLISION; // File already exist because
                                            // GetFileAttributes found it
+
+	// Check first if we're trying to open a directory as a file.
+	if (fileAttr != INVALID_FILE_ATTRIBUTES &&
+		(fileAttr & FILE_ATTRIBUTE_DIRECTORY) &&
+		!(CreateOptions & FILE_DIRECTORY_FILE)) {
+		return STATUS_FILE_IS_A_DIRECTORY;
+	}
+
     handle = CreateFile(
         filePath,
         genericDesiredAccess, // GENERIC_READ|GENERIC_WRITE|GENERIC_EXECUTE,


### PR DESCRIPTION
Returning the correct error code when trying to open a directory as file. The STATUS_FILE_IS_A_DIRECTORY NTSTATUS will be returned.

This should fix #488 .