### PR TITLE
Streams flag

### DIFF
--- a/samples/dokan_mirror/mirror.c
+++ b/samples/dokan_mirror/mirror.c
@@ -1197,7 +1197,7 @@ static NTSTATUS DOKAN_CALLBACK MirrorGetVolumeInformation(
   *MaximumComponentLength = 256;
   *FileSystemFlags = FILE_CASE_SENSITIVE_SEARCH | FILE_CASE_PRESERVED_NAMES |
                      FILE_SUPPORTS_REMOTE_STORAGE | FILE_UNICODE_ON_DISK |
-                     FILE_PERSISTENT_ACLS;
+                     FILE_PERSISTENT_ACLS | FILE_NAMED_STREAMS;
 
   // File system name could be anything up to 10 characters.
   // But Windows check few feature availability based on file system name.


### PR DESCRIPTION
For issue #490: FILE_NAMED_STREAMS flag 

set FILE_NAMED_STREAMS in FileSystemFlags  MirrorGetVolumeInformation() in mirror.c.

Do not append slash to path in front of filename if filename is a stream (DokanDispatchCreate() in create.c).
Also, do not prepend path (\) in front of filename if file is really an alternate data stream of the root directory.