### PR TITLE
Ensure the Security Descriptor length is set in mirror

### DIFF
--- a/samples/dokan_mirror/mirror.c
+++ b/samples/dokan_mirror/mirror.c
@@ -1156,6 +1156,12 @@ static NTSTATUS DOKAN_CALLBACK MirrorGetFileSecurity(
       return DokanNtStatusFromWin32(error);
     }
   }
+  
+  // Ensure the Security Descriptor Length is set
+  DWORD securityDescriptorLength = GetSecurityDescriptorLength(SecurityDescriptor);
+  DbgPrint(L"  isGetUserObjectSecuritySuccessful is true,  *LengthNeeded = securityDescriptorLength \n");
+  *LengthNeeded = securityDescriptorLength;
+
   CloseHandle(handle);
 
   return STATUS_SUCCESS;


### PR DESCRIPTION
For some cases, the GetUserObjectSecurity function will return success but not set the output parameter LengthNeeded. This fix ensure the length is well set.

This fix would fix part of the issue on #476 and save the file correctly. Re-implement #507  to look more clean.