### PR TITLE
Run IFSTest on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@
       CYG_CACHE: '%DOKAN_CI_CACHE%\cygwin'
       MSYS2_CACHE: '%DOKAN_CI_CACHE%\msys2'
       CHOCO_CACHE: '%DOKAN_CI_CACHE%\choco'
+      WLK_INST_CACHE: '%DOKAN_CI_CACHE%\wlk_inst'
 
   os: Visual Studio 2015
   version: 1.0.3-{build}
@@ -18,6 +19,7 @@
   - All
   - Coverity
   - FsTest
+
   platform:
   - x64
   
@@ -57,6 +59,14 @@
           if ($LASTEXITCODE -ne 0) {
             throw ("Command returned non-zero error-code ${LASTEXITCODE}: $command")
           }
+        }
+    - ps: |
+        if ($env:CONFIGURATION -eq "FsTest") {
+          Exec-External {& net user dokan_ifstest D0kan_1fstest /ADD }
+        }
+    - ps: |
+        if ($env:CONFIGURATION -eq "FsTest") {
+          .\scripts\install_wlk_ifstest.ps1
         }
     - ps: |
         if ($env:CONFIGURATION -eq "All") {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@
 
   platform:
   - x64
-  
+
   cache:
   - '%DOKAN_CI_CACHE% -> appveyor.yml'
 
@@ -72,7 +72,7 @@
         if ($env:CONFIGURATION -eq "All") {
           Exec-External {& choco install "--cache-location=${env:CHOCO_CACHE}" doxygen.portable}
         }
-  
+
     - ps: |
         if ($env:CONFIGURATION -eq "All") {
           function downloadIfOlderThanDays($url, $path, $days) {
@@ -84,18 +84,18 @@
 
           downloadIfOlderThanDays "https://cygwin.com/setup-x86.exe" "${env:DOKAN_CI_CACHE}\setup-x86.exe" 7
           downloadIfOlderThanDays "https://cygwin.com/setup-x86_64.exe" "${env:DOKAN_CI_CACHE}\setup-x86_64.exe" 7
-          
+
           function updateCygwin($cygwinexe, $installFolder, $cacheFolder) {
             Write-Host "Update Cygwin: $cygwinexe"
             Exec-External {& cmd /c $cygwinexe -gqnNdO -R $installFolder -s http://mirrors.kernel.org/sourceware/cygwin/ -l $cacheFolder -P cmake -P make -P gcc-core -P gcc-g++ -P pkg-config}
             Write-Host "Update Cygwin: $cygwinexe " -NoNewLine
             Write-Host "[ OK ]" -ForegroundColor Green
           }
-          
+
           updateCygwin "${env:DOKAN_CI_CACHE}\setup-x86.exe" C:/cygwin $env:CYG_CACHE
           updateCygwin "${env:DOKAN_CI_CACHE}\setup-x86_64.exe" C:/cygwin64 $env:CYG_CACHE
         }
-        
+
     - ps: |
         if ($env:CONFIGURATION -eq "All") {
           function bash($bash_command) {
@@ -153,8 +153,9 @@
         Write-Host Dokan cert installed !
       }
 
+  - ps: |
       if ($env:CONFIGURATION -eq "Coverity") {
-        
+
         if (!"$env:CoverityProjectToken") {
           Add-AppveyorMessage -Message "Not running Coverity due to missing credential. Is this a fork or a pull request?" -Category Information
           return;
@@ -164,7 +165,7 @@
         "/l:C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll",
         "/p:Configuration=Win10 Debug",
         "/p:Platform=$env:PLATFORM")
-          
+
         Exec-External {& "cov-build.exe" `
         --dir cov-int `
         --encoding=UTF-8 `
@@ -177,7 +178,7 @@
         -i "$env:APPVEYOR_BUILD_FOLDER\cov-int" `
         -o "$env:APPVEYOR_BUILD_FOLDER\coverity.zip" `
         --overwrite}
-        
+
         Write-Host "Uploading Coverity results..."
         Exec-External {& PublishCoverity\tools\PublishCoverity.exe publish `
         --nologo `
@@ -187,15 +188,17 @@
         -z "coverity.zip" `
         -d "Appveyor build." `
         --codeVersion "$env:APPVEYOR_BUILD_VERSION"}
-      
-      } elseif ($env:CONFIGURATION -eq "All") {
+      }
+
+  - ps: |
+      if ($env:CONFIGURATION -eq "All") {
 
         $env:Path = $env:Path + ";C:\Program Files (x86)\WiX Toolset v3.10;C:\Program Files (x86)\Windows Kits\8.1\bin\x64\"
-              
+
         installDokanCert
-        
+
         cd dokan_wix
-        
+
         $xmlversion = [xml](Get-Content ".\version.xml")
         $current_build_version = $xmlversion.Include.define | Where { $_.StartsWith("BuildVersion=") }
         $mm_version = $current_build_version.Split("=")[1] -replace '"','';
@@ -203,7 +206,7 @@
         $mm_version += $env:APPVEYOR_BUILD_NUMBER;
         (Get-Content ..\CHANGELOG.md) -replace '[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,4}', ($env:APPVEYOR_BUILD_VERSION.Split("-")[0] + '.' + $mm_version) | out-file "..\CHANGELOG.md"
         $installer_version = $env:APPVEYOR_BUILD_VERSION.Split("-")[0] + '.' + $mm_version;
-        
+
         $Platform = "Any CPU"
         $buildArgs = @(
         "SetAssemblyVersion.sln",
@@ -212,9 +215,9 @@
         "/p:Configuration=Release",
         "/p:Platform=${Platform}")
         & $buildCmd $buildArgs
-        
+
         & .\SetAssemblyVersion\bin\Release\SetAssemblyVersion ..\CHANGELOG.md version.xml ..\
-        
+
         cd ..
         Exec-External {& .\build.bat}
         .\cert\dokan-sign.ps1
@@ -222,7 +225,7 @@
         cd dokan_wix
         (gc version.xml) -replace 'BuildCygwin="false"', 'BuildCygwin="true"' | sc version.xml
         (gc version.xml) -replace 'Compressed="no"', 'Compressed="yes"' | sc version.xml
-        
+
         $Platform = "Mixed Platforms"
         $buildArgs = @(
         "Dokan_WiX.sln",
@@ -230,48 +233,53 @@
         "/l:C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll",
         "/p:Configuration=Release",
         "/p:Platform=${Platform}")
-        
+
         Exec-External {& $buildCmd $buildArgs}
-        
+
         Write-Host Upload Artifact...
         Push-AppveyorArtifact "${env:APPVEYOR_BUILD_FOLDER}\dokan_wix\Bootstrapper\bin\Release\DokanSetup.exe" -FileName ("DokanSetup-" + $installer_version + ".exe")
         Write-Host Artifact uploaded!
-        
-      } elseif ($env:CONFIGURATION -eq "FsTest") {
+      }
+
+  - ps: |
+      if ($env:CONFIGURATION -eq "FsTest") {
         $env:Path = $env:Path + ";C:\Program Files (x86)\Windows Kits\8.1\bin\x64\"
-        
+
         $buildArgs = @(
         "/m",
         "/l:C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll",
         "/p:Configuration=Win8.1 Release",
         "/p:Platform=$env:PLATFORM")
-        
+
         & $buildCmd $buildArgs
-        
+
         $buildArgs = @(
         "/m",
         "/l:C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll",
         "/p:Configuration=Release",
         "/p:Platform=$env:PLATFORM")
-        
+
         & $buildCmd $buildArgs
 
         installDokanCert
-        
+
         .\cert\dokan-sign.ps1
-        
+
         cp .\x64\Win8.1Release\dokan1.sys C:\Windows\System32\drivers\
         Exec-External {& .\x64\Release\dokanctl.exe /i d}
         Exec-External {& .\x64\Release\dokanctl.exe /i n}
-        
+
         cd .\samples
         .\mirror_test.ps1
-        
+
         Exec-External {& verifier /query}
       }
+
+  - ps: |
       Write-Host Build Finished !
 
   test: off
+
   on_success:
     - ps: |
         # AppVeyor does not provide us with the SHA1 before the push
@@ -307,7 +315,7 @@
             if (!$env:AccessTokenDokanDoc -or "$env:APPVEYOR_PULL_REQUEST_TITLE" -or "$env:APPVEYOR_REPO_BRANCH" -ne "master") {
               return;
             }
-          
+
             cd $env:APPVEYOR_BUILD_FOLDER\documentations
             Exec-External {& git config --global user.email "appveyor@appveyor.org"}
             Exec-External {& git config --global user.name "appveyor"}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -118,24 +118,6 @@
         }
 
   before_build:
-  - ps: |
-      # checking for BSOD
-      $bugchecks = (Get-EventLog -LogName system | Where-Object {$_.eventID -eq '1001' -and $_.Source -eq 'BugCheck'} | Select-Object -Property *)
-      if ($bugchecks) {
-        Write-Host "It seems like we rebooted due to a bugcheck (BSOD)."
-        Format-List -InputObject $bugchecks | Out-String | Out-Host
-        $memdumpArchive = "memory_dmp_$(& git rev-parse --short HEAD)_${env:APPVEYOR_BUILD_VERSION}.7z"
-        Write-Host "Compressing MEMORY.DMP"
-        Exec-External { &7z a -t7z $memdumpArchive "$env:WINDIR\MEMORY.DMP" }
-        Push-AppveyorArtifact $memdumpArchive
-        Write-Host "MEMORY.DMP uploaded as build artifact $memdumpArchive"
-        Add-AppveyorMessage `
-          -Category Error `
-          -Message "BSOD encountered during $env:CONFIGURATION. Link to MEMORY.DMP in the description " `
-          -Details ("MEMORY.DMP is available here: " + `
-            "https://ci.appveyor.com/api/buildjobs/$([System.Web.HttpUtility]::UrlEncode($env:APPVEYOR_JOB_ID))/artifacts/$([System.Web.HttpUtility]::UrlEncode($memdumpArchive))")
-        throw "Build failed due to BSOD during $env:CONFIGURATION"
-      }
   # Remove VS build warning http://help.appveyor.com/discussions/problems/4569-the-target-_convertpdbfiles-listed-in-a-beforetargets-attribute-at-c-does-not-exist-in-the-project-and-will-be-ignored
   - del "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
 
@@ -277,6 +259,42 @@
 
   - ps: |
       Write-Host Build Finished !
+
+  after_build:
+  - ps: |
+      # This function has already been defined above, but in case of a reboot caused by a BSOD, we cannot
+      # rely on it being defined!
+      function Exec-External {
+        param(
+          [Parameter(Position=0,Mandatory=1)][scriptblock] $command
+        )
+        & $command
+        if ($LASTEXITCODE -ne 0) {
+          throw ("Command returned non-zero error-code ${LASTEXITCODE}: $command")
+        }
+      }
+  - ps: |
+      # checking for BSOD
+      $bugchecks = (Get-EventLog -LogName system | Where-Object {$_.eventID -eq '1001' -and $_.Source -eq 'BugCheck'} | Select-Object -Property *)
+      if ($bugchecks) {
+        Write-Host "It seems like we rebooted due to a bugcheck (BSOD)."
+        Format-List -InputObject $bugchecks | Out-String | Out-Host
+        # events are sorted descendingly by time, so $bugchecks[0] is the latest BSOD
+        $memory_dmp = $bugchecks[0].ReplacementStrings[1]
+        Write-Host Calling KD to get more information...
+        Exec-External {& "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\kd.exe" -lines -z $memory_dmp -y "SRV*${env:APPVEYOR_BUILD_FOLDER}\x64\Win8.1Release\*http://msdl.microsoft.com/download/symbols" -c "!analyze -v; kp; dv /t /i /V; q" }
+        $memdumpArchive = "memory_dmp_$(& git rev-parse --short HEAD)_${env:APPVEYOR_BUILD_VERSION}.7z"
+        Write-Host "Compressing $memory_dmp"
+        Exec-External { &7z a -t7z $memdumpArchive $memory_dmp "${env:APPVEYOR_BUILD_FOLDER}\x64\" }
+        Push-AppveyorArtifact $memdumpArchive
+        Write-Host "MEMORY.DMP uploaded as build artifact $memdumpArchive"
+        Add-AppveyorMessage `
+          -Category Error `
+          -Message "BSOD encountered during $env:CONFIGURATION. Link to MEMORY.DMP in the description" `
+          -Details ("MEMORY.DMP is available here: " + `
+            "https://ci.appveyor.com/api/buildjobs/$([System.Web.HttpUtility]::UrlEncode($env:APPVEYOR_JOB_ID))/artifacts/$([System.Web.HttpUtility]::UrlEncode($memdumpArchive))")
+        throw "Build failed due to BSOD during $env:CONFIGURATION"
+      }
 
   test: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,17 +12,28 @@
       MSYS2_CACHE: '%DOKAN_CI_CACHE%\msys2'
       CHOCO_CACHE: '%DOKAN_CI_CACHE%\choco'
       WLK_INST_CACHE: '%DOKAN_CI_CACHE%\wlk_inst'
+      DOKAN_MAIN_BUILD_JOB_NAME: "Image: Visual Studio 2015; Configuration: All"
 
-  os: Visual Studio 2015
   version: 1.0.3-{build}
   configuration:
   - All
   - Coverity
   - FsTest
 
-  platform:
-  - x64
-
+  image:
+    - Visual Studio 2015
+    - Visual Studio 2017
+# If you suspect some changes on the AppVeyor-side breaking things,
+# uncomment below. https://www.appveyor.com/updates/
+#    - Previous Visual Studio 2015
+#    - Previous Visual Studio 2017
+  matrix:
+    exclude:
+      - configuration: All
+        image: Visual Studio 2017
+      - configuration: Coverity
+        image: Visual Studio 2017
+  max_jobs: 1
   cache:
   - '%DOKAN_CI_CACHE% -> appveyor.yml'
 
@@ -36,8 +47,11 @@
 
   install:
     - ps: |
+        if ($env:CONFIGURATION -eq "FsTest" -or $env:CONFIGURATION -eq "All") {
+          .\cert\dokan-import.ps1
+        }
+    - ps: |
         if ($env:CONFIGURATION -eq "FsTest") {
-          & Bcdedit.exe -set TESTSIGNING ON
           & verifier /standard /driver dokan1.sys
           Write-Host "Before reboot"
           Start-Sleep -s 2
@@ -66,13 +80,12 @@
         }
     - ps: |
         if ($env:CONFIGURATION -eq "FsTest") {
-          .\scripts\install_wlk_ifstest.ps1
+          Exec-External {& powershell .\scripts\install_wlk_ifstest.ps1 }
         }
     - ps: |
         if ($env:CONFIGURATION -eq "All") {
           Exec-External {& choco install "--cache-location=${env:CHOCO_CACHE}" doxygen.portable}
         }
-
     - ps: |
         if ($env:CONFIGURATION -eq "All") {
           function downloadIfOlderThanDays($url, $path, $days) {
@@ -126,15 +139,6 @@
       Write-Host Start building...
       $buildCmd = "C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe"
 
-      function installDokanCert() {
-        Write-Host Install cert and sign...
-        .\cert\dokan-import.ps1
-        $env:CERTISSUER="DokanCA"
-        $env:ADDITIONALCERT="$pwd\cert\DokanCA.cer"
-        $env:SIGNTOOL="C:\Program Files (x86)\Windows Kits\8.1\bin\x64\signtool.exe"
-        Write-Host Dokan cert installed !
-      }
-
   - ps: |
       if ($env:CONFIGURATION -eq "Coverity") {
 
@@ -173,22 +177,22 @@
       }
 
   - ps: |
+      # Available in all configurations
+      $xmlversion = [xml](Get-Content "${env:APPVEYOR_BUILD_FOLDER}\dokan_wix\version.xml")
+      $current_build_version = $xmlversion.Include.define | Where { $_.StartsWith("BuildVersion=") }
+      $mm_version = $current_build_version.Split("=")[1] -replace '"','';
+      $mm_version = $mm_version.Substring(0, $mm_version.Length - $env:APPVEYOR_BUILD_NUMBER.Length - 1);
+      $mm_version += $env:APPVEYOR_BUILD_NUMBER;
+      (Get-Content "${env:APPVEYOR_BUILD_FOLDER}\CHANGELOG.md") -replace '[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,4}', ($env:APPVEYOR_BUILD_VERSION.Split("-")[0] + '.' + $mm_version) | out-file "${env:APPVEYOR_BUILD_FOLDER}\CHANGELOG.md"
+      $installer_version = $env:APPVEYOR_BUILD_VERSION.Split("-")[0] + '.' + $mm_version;
+  - ps: |
       if ($env:CONFIGURATION -eq "All") {
-
         $env:Path = $env:Path + ";C:\Program Files (x86)\WiX Toolset v3.10;C:\Program Files (x86)\Windows Kits\8.1\bin\x64\"
-
-        installDokanCert
+        $env:CERTISSUER="DokanCA"
+        $env:ADDITIONALCERT="$pwd\cert\DokanCA.cer"
+        $env:SIGNTOOL="C:\Program Files (x86)\Windows Kits\8.1\bin\x64\signtool.exe"
 
         cd dokan_wix
-
-        $xmlversion = [xml](Get-Content ".\version.xml")
-        $current_build_version = $xmlversion.Include.define | Where { $_.StartsWith("BuildVersion=") }
-        $mm_version = $current_build_version.Split("=")[1] -replace '"','';
-        $mm_version = $mm_version.Substring(0, $mm_version.Length - $env:APPVEYOR_BUILD_NUMBER.Length - 1);
-        $mm_version += $env:APPVEYOR_BUILD_NUMBER;
-        (Get-Content ..\CHANGELOG.md) -replace '[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,4}', ($env:APPVEYOR_BUILD_VERSION.Split("-")[0] + '.' + $mm_version) | out-file "..\CHANGELOG.md"
-        $installer_version = $env:APPVEYOR_BUILD_VERSION.Split("-")[0] + '.' + $mm_version;
-
         $Platform = "Any CPU"
         $buildArgs = @(
         "SetAssemblyVersion.sln",
@@ -200,7 +204,7 @@
 
         & .\SetAssemblyVersion\bin\Release\SetAssemblyVersion ..\CHANGELOG.md version.xml ..\
 
-        cd ..
+        cd ${env:APPVEYOR_BUILD_FOLDER}
         Exec-External {& .\build.bat}
         .\cert\dokan-sign.ps1
 
@@ -225,42 +229,45 @@
 
   - ps: |
       if ($env:CONFIGURATION -eq "FsTest") {
-        $env:Path = $env:Path + ";C:\Program Files (x86)\Windows Kits\8.1\bin\x64\"
+        Write-Host "Getting main build job id via API..."
+        $api_build_info_url = "${env:APPVEYOR_URL}/api/projects/${env:APPVEYOR_ACCOUNT_NAME}/${env:APPVEYOR_PROJECT_SLUG}/build/${env:APPVEYOR_BUILD_VERSION}"
+        $headers = @{
+          "Content-Type" = "application/json"
+        }
+        $build_info = Invoke-RestMethod -Method Get -Uri $api_build_info_url -Headers $headers -UserAgent "Dokany CI-Script ${env:APPVEYOR_JOB_ID}"
+        $main_build_job_id = ($build_info.Build.jobs | Where-Object {$_.name -eq $env:DOKAN_MAIN_BUILD_JOB_NAME}).jobId
+        $installer_url = "${env:APPVEYOR_URL}/api/buildjobs/${main_build_job_id}/artifacts/DokanSetup-${installer_version}.exe"
 
-        $buildArgs = @(
-        "/m",
-        "/l:C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll",
-        "/p:Configuration=Win8.1 Release",
-        "/p:Platform=$env:PLATFORM")
+        Write-Host "Downloading installer artifact from main build job ${main_build_job_id}..."
+        Invoke-WebRequest $installer_url -OutFile DokanSetup.exe
 
-        & $buildCmd $buildArgs
+        Write-Host "Installing Dokan..."
+        $install_process = Start-Process -PassThru -Wait -FilePath .\DokanSetup.exe -ArgumentList @("/quiet", "/norestart", "/log", "dokan_install.log")
+        if ($install_process.ExitCode -ne 0) {
+          Write-Error "Dokan-Installation failed. Log below this line:"
+          Get-Content dokan_install*.log   # wildcard for getting both MSI and bundle log
+          throw "Dokan-Installation failed. Log above this line"
+        }
+      }
+  - ps: |
+      Write-Host Build finished!
 
-        $buildArgs = @(
-        "/m",
-        "/l:C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll",
-        "/p:Configuration=Release",
-        "/p:Platform=$env:PLATFORM")
-
-        & $buildCmd $buildArgs
-
-        installDokanCert
-
-        .\cert\dokan-sign.ps1
-
-        cp .\x64\Win8.1Release\dokan1.sys C:\Windows\System32\drivers\
-        Exec-External {& .\x64\Release\dokanctl.exe /i d}
-        Exec-External {& .\x64\Release\dokanctl.exe /i n}
+  test_script:
+  - ps: |
+      if ($env:CONFIGURATION -eq "FsTest") {
+        Write-Host Running tests...
+        $env:DokanLibrary1 = [System.Environment]::GetEnvironmentVariable("DokanLibrary1", "Machine")
+        $mirrors = @("${env:DokanLibrary1}\sample\mirror\mirror.exe", "${env:DokanLibrary1}\x86\sample\mirror\mirror.exe")
 
         cd .\samples
-        .\mirror_test.ps1
-
-        Exec-External {& verifier /query}
+        .\mirror_test.ps1 -Mirrors $mirrors
+      }
+  - ps: |
+      if ($env:CONFIGURATION -eq "FsTest") {
+        Write-Host Test finished!
       }
 
-  - ps: |
-      Write-Host Build Finished !
-
-  after_build:
+  after_test:
   - ps: |
       # This function has already been defined above, but in case of a reboot caused by a BSOD, we cannot
       # rely on it being defined!
@@ -274,6 +281,10 @@
         }
       }
   - ps: |
+      if ($env:CONFIGURATION -eq "FsTest") {
+        Exec-External {& verifier /query}
+      }
+  - ps: |
       # checking for BSOD
       $bugchecks = (Get-EventLog -LogName system | Where-Object {$_.eventID -eq '1001' -and $_.Source -eq 'BugCheck'} | Select-Object -Property *)
       if ($bugchecks) {
@@ -281,11 +292,14 @@
         Format-List -InputObject $bugchecks | Out-String | Out-Host
         # events are sorted descendingly by time, so $bugchecks[0] is the latest BSOD
         $memory_dmp = $bugchecks[0].ReplacementStrings[1]
+
         Write-Host Calling KD to get more information...
-        Exec-External {& "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\kd.exe" -lines -z $memory_dmp -y "SRV*${env:APPVEYOR_BUILD_FOLDER}\x64\Win8.1Release\*http://msdl.microsoft.com/download/symbols" -c "!analyze -v; kp; dv /t /i /V; q" }
+        # somehow the env-var-changes by the installer are sometimes lost after the BSOD. Hardcode the path!
+        $driver_and_pdb_path = Resolve-Path 'C:\Program Files\Dokan\Dokan Library-*\driver\'
+        & "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\kd.exe" -lines -z $memory_dmp -y "SRV*;${driver_and_pdb_path};http://msdl.microsoft.com/download/symbols" -c "!analyze -v; kp; dv /t /i /V; q"
         $memdumpArchive = "memory_dmp_$(& git rev-parse --short HEAD)_${env:APPVEYOR_BUILD_VERSION}.7z"
         Write-Host "Compressing $memory_dmp"
-        Exec-External { &7z a -t7z $memdumpArchive $memory_dmp "${env:APPVEYOR_BUILD_FOLDER}\x64\" }
+        Exec-External { &7z a -t7z $memdumpArchive $memory_dmp }
         Push-AppveyorArtifact $memdumpArchive
         Write-Host "MEMORY.DMP uploaded as build artifact $memdumpArchive"
         Add-AppveyorMessage `
@@ -293,10 +307,9 @@
           -Message "BSOD encountered during $env:CONFIGURATION. Link to MEMORY.DMP in the description" `
           -Details ("MEMORY.DMP is available here: " + `
             "https://ci.appveyor.com/api/buildjobs/$([System.Web.HttpUtility]::UrlEncode($env:APPVEYOR_JOB_ID))/artifacts/$([System.Web.HttpUtility]::UrlEncode($memdumpArchive))")
+
         throw "Build failed due to BSOD during $env:CONFIGURATION"
       }
-
-  test: off
 
   on_success:
     - ps: |

--- a/scripts/install_wlk_ifstest.ps1
+++ b/scripts/install_wlk_ifstest.ps1
@@ -1,0 +1,104 @@
+# How to prevent downloading gigabytes of stuff (I am sure there are easier ways)
+# 1. Get the URL of HLKSetup.exe
+# 2. Get the MSI for the file system tests: HLK Filter.Driver Content-x86_en-us.msi
+#    The files that the setup downloads are located under the directory Installers relative to HLKSetup.exe
+#    For instance, the FS-tests installer for http://download.microsoft.com/download/foo/bar/HLKSetup.exe
+#                 is located at http://download.microsoft.com/download/foo/bar/Installers/HLK Filter.Driver Content-x86_en-us.msi
+# 3. Install lessmsi: choco install lessmsi
+# 4. Try extracting the MSI-file with lessmsi. If it complains about missing cabinet files, add it to the list of
+#    files to be downloaded.
+#
+Set-StrictMode -Version 2
+# TODO: I have not managed to change the installation path
+# $installation_dir = ''
+$log_file = "ifstest_install.log"
+$temp_dir = '.\ifstest_installer'
+if (Get-Item env:WLK_INST_CACHE -ErrorAction SilentlyContinue) {
+    $temp_dir = $env:WLK_INST_CACHE
+}
+
+$hlks = @(
+    @{
+        # Anything older than Win10 (8.1, 8, 7). Only tested with 8.1. We might need an older one for Win7
+        'suitable_for_os_version' = [Environment]::OSVersion.Version -lt (New-Object 'Version' 10, 0, 0, 0);
+        'name' = 'Windows HCK for Windows 8.1 QFE Update 014 (Build ID: 8.100.27024)';
+        'base_url' = 'http://download.microsoft.com/download/6/6/B/66B3BE98-DD33-4860-A404-8F2F77EDF622/HCK/Installers/';
+        'installer_file' = 'HCK Filter.Driver Content-x86_en-us.msi';
+        'nttest_path' = "C:\Program Files (x86)\Windows Kits\8.1\Hardware Certification Kit\Tests\${env:PROCESSOR_ARCHITECTURE}\NTTEST";
+        'files' = @{
+            'HCK Filter.Driver Content-x86_en-us.msi' = '6E5987DE75ABE1258C775A6B6C60062F5BEE2DE7FDF38F94F1E4B23EEFF50730';
+            '6119459287e24c3503279ff684647c83.cab' = 'F40471EA4F6E90A6D6B698C910E3B817BD672A288ED45C52A1DB57B734A10810';
+            '9ddb34978b4f0879d46fa6380d941d00.cab' = '9FD8C0435CF17726A6D4A31475412B526653624330D9046B678155E5A73E9CD5';
+            'dc7239f1f797bdd32e0262f2556b253f.cab' = 'E279B34736495772CE464F3E25C6CD49A2BA97C4AD69D2A449F175B70323D6F0';
+            'e54a669f7bfb1c6c6ee7bba08b02a6dc.cab' = 'D7139ADC54303EB6A6B7F4F14CE875A307F268669FFCD54C7BFEAA75F00705D2';
+            'f1e419e00f0b2f836bdd5f3d26ae111d.cab' = 'C67F07F6533B4C64E69C5E2C60850490AF92459907F8CE10A108A2AD2B2184BC';
+            'fd0d8d2173424e55667bc3e935e1e376.cab' = 'FA63584DCCA98976544EF9DC5E66979B06F67A99187FEC9275599F7F258F8213';
+        };
+    },
+    #TODO: Need to find information about whether WLK is backward/forward-compatible within Win10-releases
+    @{
+        # This checks for Windows 10 "Anniversary" 1607
+        # See https://technet.microsoft.com/en-us/windows/release-info.aspx
+        'suitable_for_os_version' = [Environment]::OSVersion.Version -ge (New-Object 'Version' 10, 0, 14393, 0);
+        'name' = 'Windows HLK for Windows 10, version 1607';
+        'base_url' = 'http://download.microsoft.com/download/7/A/F/7AFE783C-59E6-49F9-80B4-D2F49917FFE6/hlk/Installers/';
+        'installer_file' = 'HLK Filter.Driver Content-x86_en-us.msi';
+        'nttest_path' = "C:\Program Files (x86)\Windows Kits\10\Hardware Lab Kit\Tests\${env:PROCESSOR_ARCHITECTURE}\NTTEST";
+        'files' = @{
+            'HLK Filter.Driver Content-x86_en-us.msi' = '10DD59CA8B47320C685EA6FBEB64BC4548AFCCE3D7CF7E143CEA68618A679D62';
+            '4c5579196433c53cc1ec3d7b40ae5fd2.cab' = '233ED34266101E2D88BB3C6EA032DC6321B83F39A7EDBB8356DF3104B241CCCF';
+            '6119459287e24c3503279ff684647c83.cab' = '32CD817A442181325F513DE3D30FAE62D2AFE4A3136CDD3BC57EA365AFE54C69';
+            'e54a669f7bfb1c6c6ee7bba08b02a6dc.cab' = 'FFABDD814B114457A084B80BEAC4500B2C64AD7F55007495D9551EA53CE18485';
+            'fd0d8d2173424e55667bc3e935e1e376.cab' = 'ADBC46F9064B5DFCC94681B1210ACDCA255646DD434EF3AFDF3FD9BFB303BFA4';
+        };
+    }
+)
+
+$hlk_info = $hlks | Where-Object {$_['suitable_for_os_version']}
+Write-Host "Using $($hlk_info['name'])"
+$base_url = $hlk_info['base_url']
+$installer_file = $hlk_info['installer_file']
+$dl_files = $hlk_info['files']
+$nttest_path = $hlk_info['nttest_path']
+
+New-Item -Type Directory -Force $temp_dir | Out-Null
+foreach ($kv in $dl_files.GetEnumerator()) {
+    $dl_filename = $kv.Name
+    $expected_sha256 = $kv.Value
+    $out_file = "${temp_dir}/${dl_filename}"
+    $url = "${base_url}/${dl_filename}"
+    if ( !(Test-Path $out_file) -Or $(Get-FileHash -Algorithm SHA256 $out_file).Hash -ne $expected_sha256) {
+        Write-Host "File $out_file not existing or hash not matching, downloading..."
+        Invoke-WebRequest $url -OutFile $out_file
+        $actual_sha256 = $(Get-FileHash -Algorithm SHA256 $out_file).Hash
+        if ($expected_sha256 -ne $actual_sha256) {
+            throw "Hash mismatch: $out_file, expected: $expected_sha256, actual: $actual_sha256"
+        }
+    }
+    else {
+        Write-Host "Skipping already downloaded file $out_file"
+    }
+}
+
+Write-Host Installing MSI
+Push-Location $temp_dir
+$log_file = "./install.log"
+$msi_proc = Start-Process -PassThru -Wait -FilePath msiexec.exe -ArgumentList @("/qn", "/norestart", "/lv*", $log_file, "/i", "`"$installer_file`"")
+Pop-Location
+if ($msi_proc.ExitCode -ne 0) {
+    Write-Error "IFSTest-Installation failed. Log below this line:"
+    Get-Content $log_file
+    throw "IFSTest-Installation failed. Log above this line"
+}
+
+# We copy some files into the same dir as the exe.
+# Setting the PATH is cumbersome, because IFSTest launches itself under a different user for some tests!
+$ifstest_dir = "${nttest_path}\BASETEST\core_file_services\ifs_test_kit\"
+$needed_files = @(
+    "${nttest_path}\BASETEST\core_file_services\shared_libs\fbslog\FbsLog.dll",
+    "${nttest_path}\commontest\ntlog\ntlogger.ini"
+    "${nttest_path}\commontest\ntlog\ntlog.dll"
+)
+Copy-Item $needed_files $ifstest_dir
+
+Write-Host "Installation successful."

--- a/scripts/run_ifstest.ps1
+++ b/scripts/run_ifstest.ps1
@@ -1,0 +1,23 @@
+Set-StrictMode -Version 2
+#TODO: Get Path via some MSI-CmdLet or Registry instead of hardcoding it
+if ([Environment]::OSVersion.Version.Major -eq 10) {
+    $hlk_path = "C:\Program Files (x86)\Windows Kits\10\Hardware Lab Kit"
+}
+else {
+    $hlk_path = "C:\Program Files (x86)\Windows Kits\8.1\Hardware Certification Kit"
+}
+
+$nttest_path = "${hlk_path}\Tests\${env:PROCESSOR_ARCHITECTURE}\NTTEST"
+$ifstest_exe = "${nttest_path}\BASETEST\core_file_services\ifs_test_kit\ifstest.exe"
+
+if (!(Test-Path $ifstest_exe)) {
+    throw "$ifstest_exe not found!"
+}
+
+& $ifstest_exe $args
+
+if ($LASTEXITCODE -ne 0) {
+   Write-Error "Non-zero exit-code: $LASTEXITCODE"
+   Exit $LASTEXITCODE
+}
+

--- a/scripts/run_ifstest.ps1
+++ b/scripts/run_ifstest.ps1
@@ -1,6 +1,6 @@
 Set-StrictMode -Version 2
 #TODO: Get Path via some MSI-CmdLet or Registry instead of hardcoding it
-if ([Environment]::OSVersion.Version.Major -eq 10) {
+if (([Version]$((Get-CimInstance Win32_OperatingSystem).Version)).Major -eq 10) {
     $hlk_path = "C:\Program Files (x86)\Windows Kits\10\Hardware Lab Kit"
 }
 else {

--- a/sys/create.c
+++ b/sys/create.c
@@ -605,6 +605,7 @@ Return Value:
               __leave;
             }
             relatedFileName->MaximumLength = relatedFcb->FileName.MaximumLength;
+            relatedFileName->Length = relatedFcb->FileName.Length;
             RtlUnicodeStringCopy(relatedFileName, &relatedFcb->FileName);
           }
           DokanFCBUnlock(relatedFcb);


### PR DESCRIPTION
This was more work than expected, but here it is:
* add install-script install_wlk_ifstest.ps1 for installing the IFSTest part of WLK/HCK. Currently only Win8.1 and Win10 Anniversary versions are supported. Not really sure about backward/forward compatibility of installing them on other OSes, but I think nothing bad should happen except failing tests (see the source on how to support other version or change the conditions for choosing one version over the other)
* run IFSTest from mirror_test.ps1
* Make AppVeyor re-use the installer built in the All-"Configuration", run the tests using that installer on both Win2012R2 (8.1) and and Win2016 (10 Anniversary)
* Please note that the automatic BSOD analysis does not work at the moment on AppVeyor's Win2016 (VS-2017) image, because they forgot to install windbg. You are free to download the installer and the memory.dmp from the artifacts and run windbg locally. appveyor/ci#1615

Minimum checklist before merging:
[ x ] No BSODs such as #519
[ x ] Issues filed for every skipped test that is viable to fix (see mirror_test.ps1) and issue mentioned beside the skipped test in the source code

Nice to have (maybe in a separate PR):
* AppVeyor workarounds not necessary
* Putting results into the tests-section of AppVeyor
* Calculate delta between commits e.g. when submitting a PR, compare passed/failed/skipped tests to master and post a comment in the GitHub issue.
