### PR TITLE
Fix BSOD during searching the backslash

### DIFF
--- a/sys/dokan.c
+++ b/sys/dokan.c
@@ -473,12 +473,10 @@ VOID DokanNotifyReportChange0(__in PDokanFCB Fcb, __in PUNICODE_STRING FileName,
   ASSERT(Fcb != NULL);
   ASSERT(FileName != NULL);
 
-  // search the last "\"
   nameOffset = (USHORT)(FileName->Length / sizeof(WCHAR) - 1);
-  for (; FileName->Buffer[nameOffset] != L'\\'; --nameOffset)
-    ;
-  nameOffset++; // the next is the begining of filename
 
+  // search the last "\" and then calculate the Offset in bytes
+  nameOffset = (USHORT)(DokanSearchWcharinUnicodeStringWithUlong(FileName, L'\\', (ULONG)nameOffset, 1));
   nameOffset *= sizeof(WCHAR); // Offset is in bytes
 
   FsRtlNotifyFullReportChange(Fcb->Vcb->NotifySync, &Fcb->Vcb->DirNotifyList,

--- a/sys/dokan.h
+++ b/sys/dokan.h
@@ -732,4 +732,7 @@ __inline VOID DokanClearFlag(PULONG Flags, ULONG FlagBit) {
 #define DokanCCBFlagsSetBit DokanFCBFlagsSetBit
 #define DokanCCBFlagsClearBit DokanFCBFlagsClearBit
 
+ULONG DokanSearchWcharinUnicodeStringWithUlong(__in PUNICODE_STRING inputPUnicodeString, __in WCHAR targetWchar,
+	__in ULONG offsetPosition, __in int isIgnoreTargetWchar);
+
 #endif // DOKAN_H_

--- a/sys/dokan_utility.c
+++ b/sys/dokan_utility.c
@@ -1,0 +1,61 @@
+/*
+Dokan : user-mode file system library for Windows
+
+Copyright (C) 2015 - 2017 Adrien J. <liryna.stark@gmail.com> and Maxime C. <maxime@islog.com>
+Copyright (C) 2007 - 2011 Hiroki Asakawa <info@dokan-dev.net>
+
+http://dokan-dev.github.io
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License as published by the Free
+Software Foundation; either version 3 of the License, or (at your option) any
+later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "dokan.h"
+
+/***
+  inputPUnicodeString, the input PUNICODE_STRING to search
+  targetWchar, the target WCHAR you want to search in the UNICODE_STRING
+  offsetPosition, the starting point to search
+  isIgnoreTargetWchar, boolean value, determine you want to truncate(ignore) the UNICODE_STRING with the targetWchar or not.
+
+  Example input : \\DosDevices\\Global\\Volume{D6CC17C5-1734-4085-BCE7-964F1E9F5DE9} and targetWchar = L'\\'
+  Set isIgnoreTargetWchar = 0, you are trying to get the offset in order to get something like : \Volume{D6CC17C5-1734-4085-BCE7-964F1E9F5DE9}
+  Set isIgnoreTargetWchar = 1, you are trying to get the offset in order to get something like : Volume{D6CC17C5-1734-4085-BCE7-964F1E9F5DE9}
+
+*/
+ULONG DokanSearchWcharinUnicodeStringWithUlong(__in PUNICODE_STRING inputPUnicodeString, __in WCHAR targetWchar,
+	__in ULONG offsetPosition, __in int isIgnoreTargetWchar) {
+
+	ASSERT(inputPUnicodeString != NULL);
+
+	if (offsetPosition > inputPUnicodeString->MaximumLength)
+	{
+		// trying to prevent BSOD for invalid input parameter
+		offsetPosition = inputPUnicodeString->Length;
+		// if inputPUnicodeString->Length == 0, the while loop will be skiped directly. So, the return value will be 0.
+	}
+
+	// 0 > 0 will return false and end the loop
+	while (offsetPosition > 0)
+	{
+		offsetPosition--;
+
+		if (inputPUnicodeString->Buffer[offsetPosition] == targetWchar)
+		{
+			if (isIgnoreTargetWchar == 1) {
+				offsetPosition++; // the next is the begining of filename
+			}
+			break;
+		}
+	}
+	return offsetPosition;
+}

--- a/sys/event.c
+++ b/sys/event.c
@@ -622,8 +622,8 @@ DokanEventStart(__in PDEVICE_OBJECT DeviceObject, _Inout_ PIRP Irp) {
   // Finds the last '\' and copy into DeviceName.
   // DeviceName is \Volume{D6CC17C5-1734-4085-BCE7-964F1E9F5DE9}
   deviceNamePos = dcb->SymbolicLinkName->Length / sizeof(WCHAR) - 1;
-  for (; dcb->SymbolicLinkName->Buffer[deviceNamePos] != L'\\'; --deviceNamePos)
-    ;
+  deviceNamePos = DokanSearchWcharinUnicodeStringWithUlong(dcb->SymbolicLinkName, L'\\', deviceNamePos, 0);
+
   RtlStringCchCopyW(driverInfo->DeviceName,
                     sizeof(driverInfo->DeviceName) / sizeof(WCHAR),
                     &(dcb->SymbolicLinkName->Buffer[deviceNamePos]));

--- a/sys/sys.vcxproj
+++ b/sys/sys.vcxproj
@@ -918,6 +918,7 @@
     <ClCompile Include="directory.c" />
     <ClCompile Include="dispatch.c" />
     <ClCompile Include="dokan.c" />
+    <ClCompile Include="dokan_utility.c" />
     <ClCompile Include="event.c" />
     <ClCompile Include="except.c" />
     <ClCompile Include="fileinfo.c" />

--- a/sys/sys.vcxproj.filters
+++ b/sys/sys.vcxproj.filters
@@ -85,6 +85,9 @@
     <ClCompile Include="pnp.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="dokan_utility.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="dokan.h">

--- a/sys/timeout.c
+++ b/sys/timeout.c
@@ -53,8 +53,8 @@ VOID DokanUnmount(__in PDokanDCB Dcb) {
   }
 
   deviceNamePos = Dcb->SymbolicLinkName->Length / sizeof(WCHAR) - 1;
-  for (; Dcb->SymbolicLinkName->Buffer[deviceNamePos] != L'\\'; --deviceNamePos)
-    ;
+  deviceNamePos = DokanSearchWcharinUnicodeStringWithUlong(Dcb->SymbolicLinkName, L'\\', deviceNamePos, 0);
+
   RtlStringCchCopyW(eventContext->Operation.Unmount.DeviceName,
                     sizeof(eventContext->Operation.Unmount.DeviceName) /
                         sizeof(WCHAR),


### PR DESCRIPTION
Adding a function for searching WCHAR in PUNICODE_STRING. This function avoid BSOD caused by the characteristics of unsigned type. Replace the similar searching implement in dokan/sys project with this new implemented function.

This will fix #549 . Fixed typo in #553 .