### PR TITLE
Add Impersonate Option for Security Enhancement.

### DIFF
--- a/samples/dokan_mirror/mirror.c
+++ b/samples/dokan_mirror/mirror.c
@@ -43,6 +43,7 @@ THE SOFTWARE.
 BOOL g_UseStdErr;
 BOOL g_DebugMode;
 BOOL g_HasSeSecurityPrivilege;
+BOOL g_ImpersonateCallerUser;
 
 static void DbgPrint(LPCWSTR format, ...) {
   if (g_DebugMode) {
@@ -206,6 +207,8 @@ MirrorCreateFile(LPCWSTR FileName, PDOKAN_IO_SECURITY_CONTEXT SecurityContext,
   DWORD error = 0;
   SECURITY_ATTRIBUTES securityAttrib;
   ACCESS_MASK genericDesiredAccess;
+  // userTokenHandle is for Impersonate Caller User Option
+  HANDLE userTokenHandle;
 
   securityAttrib.nLength = sizeof(securityAttrib);
   securityAttrib.lpSecurityDescriptor =
@@ -329,11 +332,30 @@ MirrorCreateFile(LPCWSTR FileName, PDOKAN_IO_SECURITY_CONTEXT SecurityContext,
     DbgPrint(L"\tUNKNOWN creationDisposition!\n");
   }
 
+  if (g_ImpersonateCallerUser) {
+	  userTokenHandle = DokanOpenRequestorToken(DokanFileInfo);
+
+	  if (userTokenHandle == INVALID_HANDLE_VALUE) {
+		  DbgPrint(L"  DokanOpenRequestorToken failed\n");
+		  // Should we return some error?
+	  }
+  }
+
+
   if (DokanFileInfo->IsDirectory) {
     // It is a create directory request
 
     if (creationDisposition == CREATE_NEW ||
         creationDisposition == OPEN_ALWAYS) {
+
+	  if (g_ImpersonateCallerUser) {
+		  // if g_ImpersonateCallerUser option is on, call the ImpersonateLoggedOnUser function.
+		  if (!ImpersonateLoggedOnUser(userTokenHandle)) {
+			  // handle the error if failed to impersonate
+			  DbgPrint(L"\tImpersonateLoggedOnUser failed.\n");
+		  }
+	  }
+
       //We create folder
       if (!CreateDirectory(filePath, &securityAttrib)) {
         error = GetLastError();
@@ -344,6 +366,12 @@ MirrorCreateFile(LPCWSTR FileName, PDOKAN_IO_SECURITY_CONTEXT SecurityContext,
           status = DokanNtStatusFromWin32(error);
         }
       }
+
+	  if (g_ImpersonateCallerUser) {
+		  // Clean Up operation for impersonate
+		  RevertToSelf();
+	  }
+
     }
 
     if (status == STATUS_SUCCESS) {
@@ -355,11 +383,24 @@ MirrorCreateFile(LPCWSTR FileName, PDOKAN_IO_SECURITY_CONTEXT SecurityContext,
         return STATUS_NOT_A_DIRECTORY;
       }
 
+	  if (g_ImpersonateCallerUser) {
+		  // if g_ImpersonateCallerUser option is on, call the ImpersonateLoggedOnUser function.
+		  if (!ImpersonateLoggedOnUser(userTokenHandle)) {
+			  // handle the error if failed to impersonate
+			  DbgPrint(L"\tImpersonateLoggedOnUser failed.\n");
+		  }
+	  }
+
       // FILE_FLAG_BACKUP_SEMANTICS is required for opening directory handles
       handle =
           CreateFile(filePath, genericDesiredAccess, ShareAccess,
                      &securityAttrib, OPEN_EXISTING,
                      fileAttributesAndFlags | FILE_FLAG_BACKUP_SEMANTICS, NULL);
+
+	  if (g_ImpersonateCallerUser) {
+		  // Clean Up operation for impersonate
+		  RevertToSelf();
+	  }
 
       if (handle == INVALID_HANDLE_VALUE) {
         error = GetLastError();
@@ -402,6 +443,14 @@ MirrorCreateFile(LPCWSTR FileName, PDOKAN_IO_SECURITY_CONTEXT SecurityContext,
     if (creationDisposition == TRUNCATE_EXISTING)
       genericDesiredAccess |= GENERIC_WRITE;
 
+	if (g_ImpersonateCallerUser) {
+		// if g_ImpersonateCallerUser option is on, call the ImpersonateLoggedOnUser function.
+		if (!ImpersonateLoggedOnUser(userTokenHandle)) {
+			// handle the error if failed to impersonate
+			DbgPrint(L"\tImpersonateLoggedOnUser failed.\n");
+		}
+	}
+
     handle = CreateFile(
         filePath,
         genericDesiredAccess, // GENERIC_READ|GENERIC_WRITE|GENERIC_EXECUTE,
@@ -410,6 +459,11 @@ MirrorCreateFile(LPCWSTR FileName, PDOKAN_IO_SECURITY_CONTEXT SecurityContext,
         creationDisposition,
         fileAttributesAndFlags, // |FILE_FLAG_NO_BUFFERING,
         NULL);                  // template file handle
+
+	if (g_ImpersonateCallerUser) {
+		// Clean Up operation for impersonate
+		RevertToSelf();
+	}
 
     if (handle == INVALID_HANDLE_VALUE) {
       error = GetLastError();
@@ -1429,6 +1483,7 @@ void ShowUsage() {
     "  /o (use mount manager)\t\t\t Register device to Windows mount manager.\n\t\t\t\t\t\t This enables advanced Windows features like recycle bin and more...\n"
     "  /c (mount for current session only)\t\t Device only visible for current user session.\n"
     "  /u (UNC provider name ex. \\localhost\\myfs)\t UNC name used for network volume.\n"
+    "  /p (Impersonate Caller User)\t\t\t Impersonate Caller User when getting the handle in CreateFile for operations.\n\t\t\t\t\t\t This option requires administrator right to work properly.\n"
     "  /a Allocation unit size (ex. /a 512)\t\t Allocation Unit Size of the volume. This will behave on the disk file size.\n"
     "  /k Sector size (ex. /k 512)\t\t\t Sector Size of the volume. This will behave on the disk file size.\n"
     "  /f User mode Lock\t\t\t\t Enable Lockfile/Unlockfile operations. Otherwise Dokan will take care of it.\n"
@@ -1516,6 +1571,9 @@ int __cdecl wmain(ULONG argc, PWCHAR argv[]) {
       dokanOptions->UNCName = UNCName;
       DbgPrint(L"UNC Name: %ls\n", UNCName);
       break;
+    case L'p':
+      g_ImpersonateCallerUser = TRUE;
+      break;
     case L'i':
       command++;
       dokanOptions->Timeout = (ULONG)_wtol(argv[command]);
@@ -1581,6 +1639,14 @@ int __cdecl wmain(ULONG argc, PWCHAR argv[]) {
              L"\t=> GetFileSecurity/SetFileSecurity may not work properly\n");
     fwprintf(stderr, L"\t=> Please restart mirror sample with administrator "
                      L"rights to fix it\n");
+  }
+
+  if (g_ImpersonateCallerUser && !g_HasSeSecurityPrivilege) {
+	  fwprintf(stderr, L"Impersonate Caller User requires administrator right to work properly\n");
+	  fwprintf(stderr,
+		  L"\t=> Other users may not use the drive properly\n");
+	  fwprintf(stderr, L"\t=> Please restart mirror sample with administrator "
+		  L"rights to fix it\n");
   }
 
   if (g_DebugMode) {


### PR DESCRIPTION
Add Impersonate Caller User Option for Security Enhancement. Previously implementation will always done all the operations with the mounted user access token. Adding option to use the caller access token to get the handle for completing the operations. This option requires admin right to work properly.

Can be fix the security holes mentioned in #575 when the `Impersonate Caller User Option` (require administrator right to mount) is used to mount.