### PR TITLE
FUSE: cross-compile 32-bit Cygwin DLL from 64-bit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -100,12 +100,11 @@
 
           function updateCygwin($cygwinexe, $installFolder, $cacheFolder) {
             Write-Host "Update Cygwin: $cygwinexe"
-            Exec-External {& cmd /c $cygwinexe -gqnNdO -R $installFolder -s http://mirrors.kernel.org/sourceware/cygwin/ -l $cacheFolder -P cmake -P make -P gcc-core -P gcc-g++ -P pkg-config}
+            Exec-External {& cmd /c $cygwinexe -gqnNdO -R $installFolder -s http://mirrors.kernel.org/sourceware/cygwin/ -l $cacheFolder -P cmake -P make -P gcc-core -P gcc-g++ -P pkg-config -P cygwin32-gcc-core -P cygwin32-gcc-g++}
             Write-Host "Update Cygwin: $cygwinexe " -NoNewLine
             Write-Host "[ OK ]" -ForegroundColor Green
           }
 
-          updateCygwin "${env:DOKAN_CI_CACHE}\setup-x86.exe" C:/cygwin $env:CYG_CACHE
           updateCygwin "${env:DOKAN_CI_CACHE}\setup-x86_64.exe" C:/cygwin64 $env:CYG_CACHE
         }
 

--- a/dokan_fuse/build.ps1
+++ b/dokan_fuse/build.ps1
@@ -4,9 +4,9 @@ $script:failed = 0
     $buildDir="dokan_fuse/build/Win32/Cygwin/"
     $installDir="Win32/Cygwin/"
     New-Item -Force -Type Directory $buildDir
-    & C:\cygwin\bin\bash -lc "
+    & C:\cygwin64\bin\bash -lc "
         cd '$currentPath'/'$buildDir' &&
-        cmake ../../../ -DCMAKE_INSTALL_PREFIX='../../../../$installDir' -DCMAKE_INSTALL_BINDIR=. &&
+        cmake ../../../ -DCMAKE_TOOLCHAIN_FILE=../../../cmake/toolchain-i686-pc-cygwin.cmake -DCMAKE_INSTALL_PREFIX='../../../../$installDir' -DCMAKE_INSTALL_BINDIR=. &&
         make -j `$(getconf _NPROCESSORS_ONLN) install"
     & C:\cygwin\bin\bash -lc "
         cd '$currentPath' &&

--- a/dokan_fuse/cmake/toolchain-i686-pc-cygwin.cmake
+++ b/dokan_fuse/cmake/toolchain-i686-pc-cygwin.cmake
@@ -1,0 +1,16 @@
+set(CMAKE_SYSTEM_NAME Cygwin)
+set(TOOLCHAIN_PREFIX i686-pc-cygwin)
+
+# cross compilers to use for C, C++ and Fortran
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_Fortran_COMPILER ${TOOLCHAIN_PREFIX}-gfortran)
+set(CMAKE_RC_COMPILER ${TOOLCHAIN_PREFIX}-windres)
+
+# target environment on the build host system
+set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
+
+# modify default behavior of FIND_XXX() commands
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
Cygwin64 can compile binaries for Cygwin32. Install the corresponding
cross-compiler and use it for compiling dokan_fuse.

This should save quite a bit of time spent downloading 32-bit Cygwin
updates on AppVeyor. It also makes live easier, because there is no
longer any need to install the 32-bit Cygwin in parallel to the 64-bit
one on local machines.