### PR TITLE
FUSE - Fix return correct status when file is FILE_OVERWRITE_IF or FILE_OPEN_IF successfully

### DIFF
--- a/dokan_fuse/src/fusemain.cpp
+++ b/dokan_fuse/src/fusemain.cpp
@@ -554,14 +554,13 @@ win_error impl_fuse_context::create_file(LPCWSTR file_name, DWORD access_mode,
         return win_error(STATUS_OBJECT_NAME_COLLISION, true);
       }
 
-      int res = do_open_file(file_name, share_mode, access_mode, dokan_file_info);
-      if (res == 0 &&
-        (creation_disposition == FILE_OVERWRITE_IF ||
-        creation_disposition == FILE_OPEN_IF)) {
-        res = win_error(STATUS_OBJECT_NAME_COLLISION, true);
+      if (creation_disposition == FILE_OVERWRITE_IF ||
+          creation_disposition == FILE_OPEN_IF) {
+          SetLastError(ERROR_ALREADY_EXISTS);
+          return win_error(STATUS_OBJECT_NAME_COLLISION, true);
       }
 
-      return res;
+      return do_open_file(file_name, share_mode, access_mode, dokan_file_info);
     }
   }
 }


### PR DESCRIPTION

Fixes #667  .

### Checklist

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the existing documentation
- [x ] My changes generate no new warnings
- [x ] I have updated the change log (Add/Change/Fix)
- [x ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-
-
-
