### PR TITLE
Undo commit bfccd62599ef80899929cbbdf7b8f0fc78f8f07b

### DIFF
--- a/dokan_fuse/src/fuse_opt.c
+++ b/dokan_fuse/src/fuse_opt.c
@@ -103,11 +103,12 @@ int fuse_opt_add_opt(char **opts, const char *opt)
         newopts = STRDUP(opt);
     else {
         size_t oldlen = strlen(*opts);
-        size_t newlen = oldlen + 1 + strlen(opt) + 1;
-        newopts = (char *)realloc(*opts, newlen);
+        size_t optlen = strlen(opt);
+        newopts = (char *)realloc(*opts, oldlen + 1 + optlen + 1);
         if (newopts) {
             newopts[oldlen] = ',';
-            strncpy(newopts + oldlen + 1, opt, newlen);
+            strncpy(newopts + oldlen + 1, opt, optlen);
+            newopts[oldlen + 1 + optlen] = '\0';
         }
     }
     if (!newopts)
@@ -223,19 +224,20 @@ static int process_opt_sep_arg(struct fuse_opt_context *ctx,
     int res;
     char *newarg;
     char *param;
-    size_t newarglen;
+    size_t paramlen;
 
     if (next_arg(ctx, arg) == -1)
         return -1;
 
     param = ctx->argv[ctx->argctr];
-    newarglen = sep + strlen(param) + 1;
-    newarg = (char *)malloc(newarglen);
+    paramlen = strlen(param);
+    newarg = (char *)malloc(sep + paramlen + 1);
     if (!newarg)
         return alloc_failed();
 
     memcpy(newarg, arg, sep);
-    strncpy(newarg + sep, param, newarglen);
+    strncpy(newarg + sep, param, paramlen);
+    newarg[sep+paramlen] = '\0';
     res = process_opt(ctx, opt, sep, newarg, iso);
     free(newarg);
 


### PR DESCRIPTION
Reverting commit bfccd62599ef80899929cbbdf7b8f0fc78f8f07b because it caused a crash in my fuse-nfs builds,
probably because the buffer size given to strncpy was wrong.
Why was this changed in the first place, the additional bound check
seams unnecessary, and it wasn't made sure the string would get null
terminated if it would ever somehow prevent an overflow. The only
way I see this could happen would be if the "opt" argument was changed
by a different thread in this tiny moment between strlen and strcpy,
if that's even possible, and even then, why would anyone ever do that,
an attacker would already have control over the program at that stage.
