### PR TITLE
Revert "Improve windows header include typo"

### DIFF
--- a/dokan/dokan.h
+++ b/dokan/dokan.h
@@ -24,7 +24,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 
 /** Do not include NTSTATUS. Fix  duplicate preprocessor definitions */
 #define WIN32_NO_STATUS
-#include <Windows.h>
+#include <windows.h>
 #undef WIN32_NO_STATUS
 #include <ntstatus.h>
 

--- a/dokan/dokani.h
+++ b/dokan/dokani.h
@@ -23,7 +23,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 #define DOKANI_H_
 
 #define WIN32_NO_STATUS
-#include <Windows.h>
+#include <windows.h>
 #undef WIN32_NO_STATUS
 #include <stdio.h>
 

--- a/dokan/list.h
+++ b/dokan/list.h
@@ -22,7 +22,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 #ifndef LIST_H_
 #define LIST_H_
 
-#include <Windows.h>
+#include <windows.h>
 
 #ifdef _MSC_VER
 #if _MSC_VER < 1300

--- a/dokan_fuse/include/fuse_win.h
+++ b/dokan_fuse/include/fuse_win.h
@@ -10,7 +10,7 @@
 
 #ifdef _MSC_VER
 #define WIN32_NO_STATUS
-#include <Windows.h>
+#include <windows.h>
 #undef WIN32_NO_STATUS
 #endif
 

--- a/dokan_fuse/src/dokanfuse.cpp
+++ b/dokan_fuse/src/dokanfuse.cpp
@@ -1,5 +1,5 @@
 #define WIN32_NO_STATUS
-#include <Windows.h>
+#include <windows.h>
 #undef WIN32_NO_STATUS
 #include <sddl.h>
 #include "utils.h"

--- a/dokan_fuse/src/fuse_helpers.c
+++ b/dokan_fuse/src/fuse_helpers.c
@@ -1,4 +1,4 @@
-#include <Windows.h>
+#include <windows.h>
 #include "fuse.h"
 
 #include <stdio.h>

--- a/dokan_fuse/src/fusemain.cpp
+++ b/dokan_fuse/src/fusemain.cpp
@@ -1,5 +1,5 @@
 #define WIN32_NO_STATUS
-#include <Windows.h>
+#include <windows.h>
 #undef WIN32_NO_STATUS
 #include <ntstatus.h>
 #include <errno.h>

--- a/dokan_fuse/src/utils.cpp
+++ b/dokan_fuse/src/utils.cpp
@@ -1,5 +1,5 @@
 #define WIN32_NO_STATUS
-#include <Windows.h>
+#include <windows.h>
 #undef WIN32_NO_STATUS
 #include <ntstatus.h>
 #include <errno.h>

--- a/dokan_np/dokannp.c
+++ b/dokan_np/dokannp.c
@@ -30,7 +30,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 #include <npapi.h>
 #include <stdio.h>
 #include <strsafe.h>
-#include <Windows.h>
+#include <windows.h>
 #include <winnetwk.h>
 
 static VOID DokanDbgPrintW(LPCWSTR format, ...) {


### PR DESCRIPTION
This reverts commit 81eca07b348e55d391f357c137adaa8fd8f11dc0. See issue #703 for details.
