### PR TITLE
VHD(X) feature

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "makevhdx"]
+	path = makevhdx
+	url = git@gitlab.com:overland-shared-sam/makevhdx.git
+	branch = refactor_for_additional_uses 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "makevhdx"]
 	path = makevhdx
-	url = git@gitlab.com:overland-shared-sam/makevhdx.git
-	branch = refactor_for_additional_uses 
+	url = git@github.com:TandbergData/makevhdx.git
+	branch = master 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased] - 1.2.0.1000
 ### Added
+- Mirror - Present mirrored device like VHD(X) disk
+- Library - Functionality to attach VHD(X) image disks to OS file sytem
+
+### Added
 - Build - Add ARM64
 
 ### Changed

--- a/dokan/dokan.def
+++ b/dokan/dokan.def
@@ -3,6 +3,8 @@ LIBRARY	dokan1
 
 EXPORTS
 
+AttachVHD
+DetachVHD
 DokanMain
 DokanUnmount
 DokanIsNameInExpression

--- a/dokan/dokan.h
+++ b/dokan/dokan.h
@@ -124,6 +124,8 @@ typedef struct _DOKAN_OPTIONS {
   ULONG SectorSize;
   /** Do need attach created vhd\vhdx disk to Windows file system? */
   BOOL  IsAttachableToFileSystem;
+  /** Path with name to attaching disk to file system */
+  LPCWSTR  AttachPath;
 } DOKAN_OPTIONS, *PDOKAN_OPTIONS;
 
 /**
@@ -719,12 +721,40 @@ typedef struct _DOKAN_OPERATIONS {
  */
 #define DOKAN_VERSION_ERROR -7
 
+ /**
+ * Dokan attach VHD(X) failed.
+ */
+#define DOKAN_ATTACH_ERROR -8
+
 /** @} */
 
 /**
  * \defgroup Dokan Dokan
  */
 /** @{ */
+
+/**
+* \brief Attach vhd\vhdx\iso disk to Windows Disk Management.
+*
+* This function attach disk.
+* If the attach fails, it will directly return a \ref error non zero.
+*
+* \param VirtualDiskPath a \ref path to virtual disk.
+* \param ReadOnly a \ref flag that show will be disk writable or not.
+* \return \ref AttachVHD status.
+*/
+DWORD DOKANAPI AttachVHD(_In_ LPCWSTR VirtualDiskPath, _In_ BOOLEAN ReadOnly);
+
+/**
+* \brief Detach vhd\vhdx\iso disk from Windows Disk Management.
+*
+* This function detach disk.
+* If the detach fails, it will directly return a \ref error non zero.
+*
+* \param VirtualDiskPath a \ref path to virtual disk.
+* \return \ref DettachVHD status.
+*/
+DWORD DOKANAPI DetachVHD(LPCWSTR VirtualDiskPath);
 
 /**
  * \brief Mount a new Dokan Volume.

--- a/dokan/dokan.h
+++ b/dokan/dokan.h
@@ -122,6 +122,8 @@ typedef struct _DOKAN_OPTIONS {
   ULONG AllocationUnitSize;
   /** Sector Size of the volume. This will affect the file size. */
   ULONG SectorSize;
+  /** Do need attach created vhd\vhdx disk to Windows file system? */
+  BOOL  IsAttachableToFileSystem;
 } DOKAN_OPTIONS, *PDOKAN_OPTIONS;
 
 /**

--- a/dokan/dokan.vcxproj
+++ b/dokan/dokan.vcxproj
@@ -204,6 +204,7 @@
       <ModuleDefinitionFile>dokan.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <AdditionalDependencies>virtdisk.lib;shlwapi.lib;rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -279,6 +280,7 @@
     <Link>
       <ModuleDefinitionFile>dokan.def</ModuleDefinitionFile>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <AdditionalDependencies>virtdisk.lib;shlwapi.lib;rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">

--- a/samples/dokan_mirror/dokan_mirror.vcxproj
+++ b/samples/dokan_mirror/dokan_mirror.vcxproj
@@ -174,11 +174,12 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CRC32C_STATIC;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalIncludeDirectories>../../sys;</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -193,11 +194,12 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CRC32C_STATIC;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalIncludeDirectories>../../sys;</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -231,11 +233,12 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CRC32C_STATIC;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalIncludeDirectories>../../sys;</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -252,9 +255,10 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CRC32C_STATIC;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../sys;</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -272,9 +276,10 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CRC32C_STATIC;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../sys;</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -312,9 +317,10 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CRC32C_STATIC;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../sys;</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -326,12 +332,18 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\makevhdx\crc32c.cpp" />
     <ClCompile Include="mirror.c" />
+    <ClCompile Include="mirror_dev.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\dokan\dokan.vcxproj">
       <Project>{f25ba22f-2ab8-4859-9b89-8fe1e774b472}</Project>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\makevhdx\VHD_VHDX_Base.h" />
+    <ClInclude Include="mirror_dev.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/samples/dokan_mirror/mirror.c
+++ b/samples/dokan_mirror/mirror.c
@@ -1365,8 +1365,6 @@ static NTSTATUS DOKAN_CALLBACK MirrorGetVolumeInformation(
   return STATUS_SUCCESS;
 }
 
-
-// Uncomment the function and set dokanOperations->GetDiskFreeSpace to personalize disk space
 /*
 static NTSTATUS DOKAN_CALLBACK MirrorDokanGetDiskFreeSpace(
     PULONGLONG FreeBytesAvailable, PULONGLONG TotalNumberOfBytes,
@@ -1503,6 +1501,7 @@ void ShowUsage() {
           "  /k Sector size (ex. /k 512)\t\t\t Sector Size of the volume. This will behave on the disk file size.\n"
           "  /f User mode Lock\t\t\t\t Enable Lockfile/Unlockfile operations. Otherwise Dokan will take care of it.\n"
           "  /i (Timeout in Milliseconds ex. /i 30000)\t Timeout until a running operation is aborted and the device is unmounted.\n\n"
+          "  /e Attach created disk to Windows file system.\n\n"
           "  /v Use vhd format for physical device mirroring instead of raw format.  This allows for interoperability with disk management on disk sizes up to 2TB\n\n"
           "  /x Use vhdx format for physical device mirroring instead of raw format.  This allows for interoperability with disk management for disk sizes up to 64TB.  Requires Windows 8/Server 2012 or later.\n\n"
           "Examples:\n"
@@ -1624,6 +1623,10 @@ int __cdecl wmain(ULONG argc, PWCHAR argv[]) {
       break;
     case L'x':
       mirrorDevType = MirrorDevTypeVHDX;
+      break;
+    case L'e':
+      dokanOptions->IsAttachableToFileSystem = TRUE;
+      DbgPrint(L"Mirrored disk will be attached");
       break;
 
     default:

--- a/samples/dokan_mirror/mirror_dev.cpp
+++ b/samples/dokan_mirror/mirror_dev.cpp
@@ -34,13 +34,6 @@ THE SOFTWARE.
 #include <stdbool.h>
 #include "../../makevhdx/VHD_VHDX_Base.h"
 
-static wchar_t *g_MirrorDevDokanPathPrefix = L"\\MIRROR";
-static size_t g_MirrorDevDokanPathPrefixLength = 8;
-static wchar_t *g_MirrorDevDokanVhdPostfix = L".VHD";
-static size_t g_MirrorDevDokanVhdPostfixLength = 4;
-static wchar_t *g_MirrorDevDokanVhdxPostfix = L".VHDX";
-static size_t g_MirrorDevDokanVhdxPostfixLength = 5;
-
 
 /**
 * Use a fixed offset with the disk - to experiment with exporting a partition only.

--- a/samples/dokan_mirror/mirror_dev.cpp
+++ b/samples/dokan_mirror/mirror_dev.cpp
@@ -1,0 +1,769 @@
+/*
+Dokan : user-mode file system library for Windows
+
+Copyright (C) 2015 - 2017 Adrien J. <liryna.stark@gmail.com> and Maxime C. <maxime@islog.com>
+Copyright (C) 2007 - 2011 Hiroki Asakawa <info@dokan-dev.net>
+
+http://dokan-dev.github.io
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#include "../../dokan/dokan.h"
+#include "../../dokan/fileinfo.h"
+#include <malloc.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <winbase.h>
+#include "mirror_dev.h"
+#include <stdbool.h>
+#include "../../makevhdx/VHD_VHDX_Base.h"
+
+static wchar_t *g_MirrorDevDokanPathPrefix = L"\\MIRROR";
+static size_t g_MirrorDevDokanPathPrefixLength = 8;
+static wchar_t *g_MirrorDevDokanVhdPostfix = L".VHD";
+static size_t g_MirrorDevDokanVhdPostfixLength = 4;
+static wchar_t *g_MirrorDevDokanVhdxPostfix = L".VHDX";
+static size_t g_MirrorDevDokanVhdxPostfixLength = 5;
+
+
+/**
+* Use a fixed offset with the disk - to experiment with exporting a partition only.
+* I've found Windows partitions typically start at offset 0x100000
+*/
+#define FIXED_OFFSET 0
+
+
+struct MirrorDevData
+{
+private:
+  /**
+  * The device file type, either raw disk image or vhd
+  */
+  enum MirrorDevFileType type;
+public:
+  /**
+  * The size of the underlying physical device
+  * to mirror in blocks
+  */
+  LONGLONG            devSizeInBlocks;
+  /**
+  * The handle to the physical device being mirrored
+  */
+  HANDLE mirrorDevPhysDevHandle;
+  /**
+  * The mutex to hold when seeking/reading on the mirror device
+  */
+  HANDLE mirrorDevAccessMutex;
+
+  std::vector<BYTE> header;
+  std::vector<BYTE> footer;
+
+  wchar_t mirrorDevDokanPathBuffer[8 + 5 + 1];
+
+  wchar_t *GetDokanMirrorDevFilePath()
+  {
+    if (mirrorDevDokanPathBuffer[0] == 0) {
+      memset(&mirrorDevDokanPathBuffer[0], 0, sizeof(mirrorDevDokanPathBuffer));
+      wcsncpy_s(&mirrorDevDokanPathBuffer[0], sizeof(mirrorDevDokanPathBuffer) / sizeof(WCHAR), &g_MirrorDevDokanPathPrefix[0], g_MirrorDevDokanPathPrefixLength);
+      if (type == MirrorDevTypeVHD) {
+        wcsncat_s(&mirrorDevDokanPathBuffer[0], sizeof(mirrorDevDokanPathBuffer) / sizeof(WCHAR), &g_MirrorDevDokanVhdPostfix[0], g_MirrorDevDokanVhdPostfixLength);
+      }
+      else if (type == MirrorDevTypeVHDX) {
+        wcsncat_s(&mirrorDevDokanPathBuffer[0], sizeof(mirrorDevDokanPathBuffer) / sizeof(WCHAR), &g_MirrorDevDokanVhdxPostfix[0], g_MirrorDevDokanVhdxPostfixLength);
+      }
+    }
+    return &mirrorDevDokanPathBuffer[0];
+  }
+  
+  size_t GetDokanMirrorDevFilePathLength()
+  {
+    return wcsnlen_s(GetDokanMirrorDevFilePath(), sizeof(mirrorDevDokanPathBuffer) / sizeof(WCHAR));
+  }
+
+  size_t GetHeaderSizeBlocks() {
+    return header.size() / MirrorDevBlockSize();
+  }
+
+  size_t GetFooterSizeBlocks() {
+    return footer.size() / MirrorDevBlockSize();
+  }
+  MirrorDevData() :
+    type(MirrorDevTypeRawFile),
+    devSizeInBlocks(0),
+    mirrorDevPhysDevHandle(NULL)
+  {
+    memset(&mirrorDevDokanPathBuffer, 0, sizeof(mirrorDevDokanPathBuffer));
+    GetDokanMirrorDevFilePath();
+    mirrorDevAccessMutex=CreateMutex(NULL, FALSE, NULL);
+  }
+
+  ~MirrorDevData()
+  {
+    CloseHandle(mirrorDevAccessMutex);
+  }
+
+  void SetType(enum MirrorDevFileType newType)
+  {
+    type = newType;
+    mirrorDevDokanPathBuffer[0] = 0;
+    GetDokanMirrorDevFilePath();
+  }
+
+#define MAX_BLOCK_SIZE 512
+  DWORD MirrorDevBlockSize()
+  {
+    /**
+    * TODO: actually look this up from device geometry
+    */
+    return MAX_BLOCK_SIZE;
+  }
+
+
+};
+
+struct MirrorDevData g_MirrorDevData;
+
+
+HANDLE GetMirrorDevHandle()
+{
+  return g_MirrorDevData.mirrorDevPhysDevHandle;
+}
+
+struct MirrorDevData &GetMirrorDevData()
+{
+  return g_MirrorDevData;
+}
+
+bool MirrorDevFileNameMatchesExpected(LPCWSTR FileName)
+{
+  size_t fileNameLength = wcslen(FileName);
+  if (fileNameLength != GetMirrorDevData().GetDokanMirrorDevFilePathLength() ||
+    (wcsncmp(FileName,
+      GetMirrorDevData().GetDokanMirrorDevFilePath(),
+      GetMirrorDevData().GetDokanMirrorDevFilePathLength()) != 0))
+  {
+    return false;
+  }
+  return true;
+}
+
+
+static NTSTATUS DOKAN_CALLBACK
+MirrorDevCreateFile(LPCWSTR FileName, PDOKAN_IO_SECURITY_CONTEXT SecurityContext,
+	ACCESS_MASK DesiredAccess, ULONG FileAttributes,
+	ULONG ShareAccess, ULONG CreateDisposition,
+	ULONG CreateOptions, PDOKAN_FILE_INFO DokanFileInfo) {
+  DbgPrint(L"DevCreateFile : %s\n", FileName);
+  DWORD creationDisposition;
+  DWORD fileAttributesAndFlags;
+  ACCESS_MASK genericDesiredAccess;
+
+  DbgPrint(L"MirrorDevCreateFile %s Share Mode 0x%x\n", FileName, ShareAccess);
+  /**
+  * TODO: figure out how to use this
+  */
+  SecurityContext = SecurityContext;
+
+  DokanMapKernelToUserCreateFileFlags(
+    DesiredAccess, FileAttributes, CreateOptions, CreateDisposition,
+    &genericDesiredAccess, &fileAttributesAndFlags, &creationDisposition);
+
+  if (FileName == NULL)
+  {
+    DbgPrint(
+      L"%s: invalid path.\n",
+      FileName);
+    return -ERROR_BAD_ARGUMENTS;
+  }
+  if ((genericDesiredAccess & GENERIC_WRITE) != 0)
+  {
+    return(-ERROR_WRITE_PROTECT);
+  }
+  /* Ignore the share_mode
+  */
+  if (creationDisposition == CREATE_NEW)
+  {
+    return(-ERROR_FILE_EXISTS);
+  }
+  else if (creationDisposition == CREATE_ALWAYS)
+  {
+    return(-ERROR_ALREADY_EXISTS);
+  }
+  else if (creationDisposition == OPEN_ALWAYS)
+  {
+    return(-ERROR_FILE_NOT_FOUND);
+  }
+  else if (creationDisposition == TRUNCATE_EXISTING)
+  {
+    return(-ERROR_FILE_NOT_FOUND);
+  }
+  else if (creationDisposition != OPEN_EXISTING)
+  {
+    DbgPrint(
+      L"invalid creation disposition 0x%x.\n",
+      creationDisposition);
+    return(-ERROR_BAD_ARGUMENTS);
+  }
+  if (DokanFileInfo == NULL)
+  {
+    DbgPrint(L"Null file info\n");
+    return(-ERROR_BAD_ARGUMENTS);
+  }
+  size_t fileNameLength = wcslen(FileName);
+  if (fileNameLength == 1)
+  {
+    if (FileName[0] != (wchar_t) '\\')
+    {
+      return -ERROR_FILE_NOT_FOUND;
+    }
+  }
+  else
+  {
+    if( !MirrorDevFileNameMatchesExpected(FileName) )
+    {
+      DbgPrint(L"Invalid file name %s\n", FileName);
+      return -ERROR_FILE_NOT_FOUND;
+    }
+  }
+  return NO_ERROR;
+
+}
+
+static void DOKAN_CALLBACK MirrorDevCloseFile(LPCWSTR FileName,
+  PDOKAN_FILE_INFO DokanFileInfo) {
+  if (DokanFileInfo->Context) {
+    DbgPrint(L"CloseFile: %s\n", FileName);
+    DbgPrint(L"\terror : not cleanuped file\n\n");
+    CloseHandle((HANDLE)DokanFileInfo->Context);
+    DokanFileInfo->Context = 0;
+  }
+  else {
+    DbgPrint(L"Close: %s\n\n", FileName);
+  }
+}
+
+
+
+bool GetMirrorDevAccessMutex(struct MirrorDevData *data)
+{
+  DWORD dwWaitResult;
+  dwWaitResult = WaitForSingleObject(
+    data->mirrorDevAccessMutex,    // handle to mutex
+    INFINITE);  // no time-out interval
+
+  return dwWaitResult == WAIT_OBJECT_0;
+}
+
+void ReleaseMirrorDevAccessMutex(struct MirrorDevData *data)
+{
+  ReleaseMutex(data->mirrorDevAccessMutex);
+}
+/**
+* Read @param LengthInBlocks blocks at @param BlockOffset blocks offset of the mirror device into @param Buffer.
+* Also handles read of vhd footer when attempts to read maxBlockOffset + 1 are issued.
+* @return true on success, false on failure.
+*/
+bool MirrorDevReadAlignedBlocks(LONGLONG BlockOffset, LPVOID Buffer, DWORD LengthInBlocks)
+{
+  DWORD bytesReadThisCall;
+  bool success = false;
+  if ( LengthInBlocks > 0 && BlockOffset >= 0 )
+  {
+    DbgPrint(L"Read %llu blocks at block offset %llu (0x%llx)\n", (unsigned long long)LengthInBlocks, (unsigned long long)BlockOffset, (unsigned long long)BlockOffset);
+    DWORD FullReadLength = LengthInBlocks * GetMirrorDevData().MirrorDevBlockSize();
+    size_t ReadLengthRemaining = FullReadLength;
+    LONGLONG DeviceStartBlockOffset = BlockOffset;
+    BYTE *BufferWriteLocation = (BYTE*)Buffer;
+    if (GetMirrorDevData().GetHeaderSizeBlocks() != 0 &&
+      BlockOffset >= (LONGLONG)GetMirrorDevData().GetHeaderSizeBlocks()) {
+      DeviceStartBlockOffset = BlockOffset - GetMirrorDevData().GetHeaderSizeBlocks();
+      DbgPrint(L"Shift device block offset to %llu (0x%llx) to account for %llu header blocks\n", 
+        (unsigned long long)DeviceStartBlockOffset, 
+        (unsigned long long)DeviceStartBlockOffset,(unsigned long long)GetMirrorDevData().GetHeaderSizeBlocks());
+    }
+    else if(GetMirrorDevData().GetHeaderSizeBlocks() != 0) {
+      size_t HeaderReadLenBlocks = min(LengthInBlocks, GetMirrorDevData().GetHeaderSizeBlocks());
+      size_t HeaderByteOffset = BlockOffset * GetMirrorDevData().MirrorDevBlockSize();
+      memcpy(&((UINT8*)Buffer)[0], &GetMirrorDevData().header.data()[HeaderByteOffset],HeaderReadLenBlocks*GetMirrorDevData().MirrorDevBlockSize());
+      BlockOffset += HeaderReadLenBlocks;
+      DeviceStartBlockOffset = 0;
+      ReadLengthRemaining -= HeaderReadLenBlocks * GetMirrorDevData().MirrorDevBlockSize();
+      if (ReadLengthRemaining == 0) {
+        success = true;
+      }
+      DbgPrint(L"Copied %llu header blocks into the buffer starting at byte offset %llu, %llu remaining bytes to be read starting at device block 0\n", 
+              (unsigned long long) HeaderReadLenBlocks, HeaderByteOffset, (unsigned long long)ReadLengthRemaining);
+      BufferWriteLocation += HeaderReadLenBlocks * GetMirrorDevData().MirrorDevBlockSize();
+    }
+    if (ReadLengthRemaining != 0) {
+      LONGLONG DeviceLastBlock = DeviceStartBlockOffset + (ReadLengthRemaining/GetMirrorDevData().MirrorDevBlockSize())-1;
+      if (DeviceLastBlock >= GetMirrorDevData().devSizeInBlocks &&
+          GetMirrorDevData().GetFooterSizeBlocks() > 0) {
+        LONGLONG BufferOffsetToVhdFooter = (GetMirrorDevData().devSizeInBlocks - DeviceStartBlockOffset)*GetMirrorDevData().MirrorDevBlockSize();
+        size_t FooterReadLenBytes = min(GetMirrorDevData().footer.size(), ReadLengthRemaining);
+        /**
+        * This is a read of the VHD footer, so copy it into the end of the buffer
+        */
+        memcpy(&((UINT8*)Buffer)[BufferOffsetToVhdFooter], GetMirrorDevData().footer.data(), FooterReadLenBytes);
+        ReadLengthRemaining -= FooterReadLenBytes;
+        DbgPrint(L"Write VHD footer to buffer in last %llu bytes starting at offset %llu\n", (unsigned long long)FooterReadLenBytes, (unsigned long long)BufferOffsetToVhdFooter);
+        if (ReadLengthRemaining == 0) {
+          success = true;
+        }
+      }
+      if (ReadLengthRemaining > 0) {
+        LARGE_INTEGER liOffset;
+        liOffset.QuadPart = DeviceStartBlockOffset * GetMirrorDevData().MirrorDevBlockSize();
+        if (GetMirrorDevAccessMutex(&g_MirrorDevData))
+        {
+          success = SetFilePointerEx(GetMirrorDevHandle(), liOffset, NULL, FILE_BEGIN);
+          if (!success) {
+            DbgPrint(L"Seek to offset %llu failed with error %d\n", liOffset.QuadPart, GetLastError());
+          }
+          else {
+            success = ReadFile(GetMirrorDevHandle(), BufferWriteLocation, (DWORD) ReadLengthRemaining, &bytesReadThisCall, NULL);
+            if (!success) {
+              DbgPrint(L"ReadFile failed with error %d reading %llu bytes at offset %llu bytes\n", GetLastError(), (unsigned long long)ReadLengthRemaining, liOffset.QuadPart);
+            }
+          }
+          ReleaseMirrorDevAccessMutex(&g_MirrorDevData);
+        }
+      }
+    }
+  }
+  return success;
+}
+bool MirrorDevReadAligned(LONGLONG BlockOffset, DWORD FirstBlockOffset, LPVOID Buffer, DWORD BufferLength, LPDWORD BytesReadReturn )
+{
+  const DWORD blockSize = GetMirrorDevData().MirrorDevBlockSize();
+  UCHAR tempBuffer[MAX_BLOCK_SIZE];
+  PUCHAR currentBufferOffset = (PUCHAR)Buffer;
+  DWORD remainingBytes = BufferLength;
+  bool success = true;
+  if ( FirstBlockOffset != 0 || remainingBytes <= blockSize )
+  {
+    DWORD firstBlockUsedBytes = min(BufferLength,blockSize- FirstBlockOffset);
+    DbgPrint(L"Reading one block for copy of %d first block bytes\n", firstBlockUsedBytes);
+    success = MirrorDevReadAlignedBlocks(BlockOffset,tempBuffer, 1);
+    if( !success )
+    {
+      DbgPrint(L"MirrorDevReadAlignedBlocks failed reading %d bytes for first block offset %d\n", GetLastError(),blockSize,FirstBlockOffset);
+    }
+    else
+    {
+      DbgPrint(L"Read %lu aligned bytes, copied %d into buffer starting at offset %d\n", blockSize, firstBlockUsedBytes, FirstBlockOffset);
+      memcpy(currentBufferOffset, &tempBuffer[FirstBlockOffset], firstBlockUsedBytes);
+      currentBufferOffset += firstBlockUsedBytes;
+      remainingBytes -= firstBlockUsedBytes;
+      BlockOffset++;
+      if (remainingBytes != 0 && remainingBytes < blockSize)
+      {
+        success = MirrorDevReadAlignedBlocks(BlockOffset, tempBuffer, 1);
+        if (success)
+        {
+          DbgPrint(L"Read %lu aligned bytes, copied %d into buffer\n", blockSize, remainingBytes);
+          memcpy(currentBufferOffset, &tempBuffer[0], remainingBytes);
+          remainingBytes = 0;
+        }
+      }
+    }
+  }
+  if (success)
+  {
+    if (remainingBytes >= blockSize)
+    {
+      DWORD alignedBlocksRead = remainingBytes/blockSize;
+      DWORD alignedBytesRead = blockSize*alignedBlocksRead;
+      success = MirrorDevReadAlignedBlocks(BlockOffset,currentBufferOffset, alignedBlocksRead);
+      if (!success)
+      {
+        DbgPrint(L"MirrorDevReadAlignedBlocks failed reading aligned payload %lu bytes\n", alignedBytesRead);
+      }
+      else
+      {
+        DbgPrint(L"Read %lu aligned blocks into buffer\n", alignedBlocksRead);
+      }
+      currentBufferOffset += alignedBytesRead;
+      remainingBytes -= alignedBytesRead;
+      BlockOffset += (alignedBytesRead / blockSize);
+      if (success && remainingBytes != 0)
+      {
+        success = MirrorDevReadAlignedBlocks(BlockOffset, tempBuffer, 1);
+        if (!success)
+        {
+          DbgPrint(L"ReadFile failed with error %d reading remainder payload %d bytes\n", GetLastError(), blockSize);
+        }
+        else
+        {
+          memcpy(currentBufferOffset, &tempBuffer[0], remainingBytes);
+          DbgPrint(L"Read %lu bytes,  copied %u into buffer \n", blockSize, remainingBytes);
+        }
+      }
+    }
+  }
+  if (success)
+  {
+    *BytesReadReturn = BufferLength;
+  }
+  return success;
+}
+
+int GetMirrorBackingDevSize(LARGE_INTEGER *size)
+{
+  DISK_GEOMETRY_EX geo;
+  DWORD returned;
+  if (!DeviceIoControl(
+    GetMirrorDevHandle(),
+    IOCTL_DISK_GET_DRIVE_GEOMETRY_EX,
+    NULL,
+    0,
+    &geo,
+    sizeof(DISK_GEOMETRY_EX),
+    &returned,
+    NULL))
+  {
+    DbgPrint(L"IOCTL_DISK_GET_DRIVE_GEOMETRY_EX returned %d\n", GetLastError());
+    return -ERROR_SEEK_ON_DEVICE;
+  }
+  else
+  {
+    geo.DiskSize.QuadPart -= FIXED_OFFSET;
+    *size = geo.DiskSize;
+    DbgPrint(L"Mirror backing disk size %llu (0x%llx) bytes\n", size->QuadPart, size->QuadPart );
+  }
+
+  return NO_ERROR;
+}
+
+int GetMirrorDevSize(LARGE_INTEGER *size)
+{
+  int rc = NO_ERROR;
+  size->QuadPart = GetMirrorDevData().devSizeInBlocks * GetMirrorDevData().MirrorDevBlockSize();
+  size->QuadPart += GetMirrorDevData().footer.size();
+  size->QuadPart += GetMirrorDevData().header.size();
+  DbgPrint(L"Mirror dev size %llu (0x%llx) bytes", size->QuadPart, size->QuadPart);
+  return rc;
+}
+
+static NTSTATUS DOKAN_CALLBACK MirrorDevReadFile(LPCWSTR FileName, LPVOID Buffer,
+  DWORD BufferLength,
+  LPDWORD ReadLength,
+  LONGLONG Offset,
+  PDOKAN_FILE_INFO DokanFileInfo) {
+  NTSTATUS rc =-ERROR_GENERIC_COMMAND_FAILED;
+  Offset += FIXED_OFFSET;
+  if (Offset < 0 ) {
+    LARGE_INTEGER devSize;
+    GetMirrorDevSize(&devSize);
+    DbgPrint(L"MirrorDevReadFile recieved negative offset 0x%llx\n", Offset);
+    Offset = devSize.QuadPart + Offset;
+  }
+  DbgPrint(L"MirrorDevReadFile %s length %lu offset %llu (0x%llx)\n", FileName, BufferLength, Offset,Offset);
+  DokanFileInfo = DokanFileInfo;
+  if (!MirrorDevFileNameMatchesExpected(FileName))
+  {
+    DbgPrint(L"Invalid file name %s\n", FileName);
+    rc=-ERROR_FILE_NOT_FOUND;
+  }
+  else
+  {
+    DWORD offsetRemainder;
+    DWORD blockSize = GetMirrorDevData().MirrorDevBlockSize();
+    offsetRemainder = Offset % blockSize;
+
+    if (MirrorDevReadAligned(Offset/ blockSize,offsetRemainder,Buffer, BufferLength, ReadLength))
+    {
+      DbgPrint(L"Read %lu bytes from device, first first 4 bytes 0x%02x%02x%02x%02x\n\n",
+        *ReadLength, ((UCHAR *)Buffer)[0], ((UCHAR *)Buffer)[1], ((UCHAR *)Buffer)[2], ((UCHAR *)Buffer)[3]);
+      rc = NO_ERROR;
+    }
+    else
+    {
+      DbgPrint(L"ReadFile failed with error %d\n", GetLastError());
+      rc = -ERROR_READ_FAULT;
+    }
+  }
+  return rc;
+}
+
+
+
+
+static NTSTATUS DOKAN_CALLBACK MirrorDevGetFileInformation(
+  LPCWSTR FileName, LPBY_HANDLE_FILE_INFORMATION HandleFileInformation,
+  PDOKAN_FILE_INFO DokanFileInfo) {
+  DbgPrint(L"MirrorDevGetFileInformation %s\n", FileName);
+  size_t fileNameLength = wcslen(FileName);
+  DokanFileInfo = DokanFileInfo;
+  if (fileNameLength == 1)
+  {
+    if (FileName[0] != (wchar_t) '\\')
+    {
+      return -ERROR_FILE_NOT_FOUND;
+    }
+    HandleFileInformation->dwFileAttributes = FILE_ATTRIBUTE_DIRECTORY;
+    /* TODO set timestamps
+    HandleFileInformation->ftCreationTime   = { 0, 0 };
+    HandleFileInformation->ftLastAccessTime = { 0, 0 };
+    HandleFileInformation->ftLastWriteTime  = { 0, 0 };
+    */
+  }
+  else
+  {
+    if (!MirrorDevFileNameMatchesExpected(FileName))
+    {
+      DbgPrint(L"Invalid file name %s\n", FileName);
+      return -ERROR_FILE_NOT_FOUND;
+    }
+    LARGE_INTEGER size;
+    int rc = GetMirrorDevSize(&size);
+    if( rc != 0 )
+    {
+      return rc;
+    }
+    HandleFileInformation->dwFileAttributes = FILE_ATTRIBUTE_READONLY;
+    /* TODO set timestamps
+    HandleFileInformation->ftCreationTime   = { 0, 0 };
+    HandleFileInformation->ftLastAccessTime = { 0, 0 };
+    HandleFileInformation->ftLastWriteTime  = { 0, 0 };
+    */
+    HandleFileInformation->nFileSizeHigh = size.HighPart;
+    HandleFileInformation->nFileSizeLow = size.LowPart;
+    DbgPrint(L"Mirror file size low part 0x%x high part 0x%x quad part %llu\n", size.LowPart, size.HighPart, size.QuadPart);
+  }
+  return NO_ERROR;
+}
+
+static NTSTATUS DOKAN_CALLBACK
+MirrorDevFindFiles(LPCWSTR FileName,
+  PFillFindData FillFindData, // function pointer
+  PDOKAN_FILE_INFO DokanFileInfo) {
+  WIN32_FIND_DATAW findData;
+  DbgPrint(L"MirrorDevFindFiles %s\n",FileName);
+  memset(&findData, 0, sizeof(WIN32_FIND_DATAW));
+  size_t fileNameLength = wcslen(FileName);
+  if ( (fileNameLength != 1) || 
+     (FileName[0] != (wchar_t) '\\') )
+  {
+    DbgPrint(L"Invalid Filename for FindFiles %s\n", FileName);
+    return -ERROR_FILE_NOT_FOUND;
+  }
+  wcsncpy_s(findData.cFileName, sizeof(findData.cFileName)/sizeof(WCHAR), L".", 1);
+  wcsncpy_s(findData.cAlternateFileName, sizeof(findData.cAlternateFileName) / sizeof(WCHAR),  L".", 1);
+  findData.dwFileAttributes = FILE_ATTRIBUTE_DIRECTORY;
+  /* TODO set timestamps
+  findData.ftCreationTime   = { 0, 0 };
+  findData.ftLastAccessTime = { 0, 0 };
+  findData.ftLastWriteTime  = { 0, 0 };
+  */
+  int rc= FillFindData(
+    &findData,
+    DokanFileInfo);
+  if( rc != 0)
+  {
+    DbgPrint(L"FillFindData returned %d on . entry\n", rc);
+    return -ERROR_GEN_FAILURE;
+  }
+  memset(&findData, 0, sizeof(WIN32_FIND_DATAW));
+  wcsncpy_s(findData.cFileName, sizeof(findData.cFileName) / sizeof(WCHAR), L"..", 1);
+  wcsncpy_s(findData.cAlternateFileName, sizeof(findData.cAlternateFileName) / sizeof(WCHAR), L"..", 1);
+  findData.dwFileAttributes = FILE_ATTRIBUTE_DIRECTORY;
+  /* TODO set timestamps
+  findData.ftCreationTime   = { 0, 0 };
+  findData.ftLastAccessTime = { 0, 0 };
+  findData.ftLastWriteTime  = { 0, 0 };
+  */
+  rc = FillFindData(
+    &findData,
+    DokanFileInfo);
+  if (rc != 0)
+  {
+    DbgPrint(L"FillFindData returned %d on .. entry\n", rc);
+    return -ERROR_GEN_FAILURE;
+  }
+  memset(&findData, 0, sizeof(WIN32_FIND_DATAW));
+  wcsncpy_s(findData.cFileName, sizeof(findData.cFileName)/sizeof(WCHAR), &(GetMirrorDevData().GetDokanMirrorDevFilePath()[1]), GetMirrorDevData().GetDokanMirrorDevFilePathLength() - 1);
+  wcsncpy_s(findData.cAlternateFileName, sizeof(findData.cAlternateFileName) / sizeof(WCHAR), &(GetMirrorDevData().GetDokanMirrorDevFilePath()[1]), GetMirrorDevData().GetDokanMirrorDevFilePathLength() - 1);
+  findData.dwFileAttributes = FILE_ATTRIBUTE_READONLY;
+
+  LARGE_INTEGER size;
+  rc = GetMirrorDevSize(&size);
+  if (rc != 0)
+  {
+    return rc;
+  }
+  findData.nFileSizeLow = size.LowPart;
+  findData.nFileSizeHigh = size.HighPart;
+  rc = FillFindData(
+    &findData,
+    DokanFileInfo);
+  if (rc != 0)
+  {
+    DbgPrint(L"FillFindData returned %d on mirror dev entry\n", rc);
+    return -ERROR_GEN_FAILURE;
+  }
+  return NO_ERROR;
+
+}
+
+static NTSTATUS DOKAN_CALLBACK MirrorDevGetVolumeInformation(
+  LPWSTR VolumeNameBuffer, DWORD VolumeNameSize, LPDWORD VolumeSerialNumber,
+  LPDWORD MaximumComponentLength, LPDWORD FileSystemFlags,
+  LPWSTR FileSystemNameBuffer, DWORD FileSystemNameSize,
+  PDOKAN_FILE_INFO DokanFileInfo) {
+  DokanFileInfo = DokanFileInfo;
+  DbgPrint(L"MirrorDevGetVolumeInformation\n");
+  wcscpy_s(VolumeNameBuffer, VolumeNameSize, &(GetMirrorDevData().GetDokanMirrorDevFilePath()[1]));
+  if (VolumeSerialNumber)
+    *VolumeSerialNumber = 0x19831116;
+  if (MaximumComponentLength)
+    *MaximumComponentLength = 255;
+  if (FileSystemFlags)
+    *FileSystemFlags = FILE_CASE_SENSITIVE_SEARCH | FILE_CASE_PRESERVED_NAMES |
+    FILE_UNICODE_ON_DISK |
+    FILE_READ_ONLY_VOLUME;
+  wcscpy_s(FileSystemNameBuffer, FileSystemNameSize, L"Dokan");
+  return NO_ERROR;
+}
+void MirrorDevFillOptions(PDOKAN_OPTIONS dokanOptions)
+{
+  DbgPrint(L"Forcing write protect since physical device implementation does not currently support reads\n");
+  dokanOptions->Options |= DOKAN_OPTION_WRITE_PROTECT;
+}
+void MirrorDevFillOperations(PDOKAN_OPERATIONS dokanOperations)
+{
+  dokanOperations->ZwCreateFile = MirrorDevCreateFile;
+  dokanOperations->CloseFile = MirrorDevCloseFile;
+  dokanOperations->ReadFile = MirrorDevReadFile;
+  dokanOperations->GetFileInformation = MirrorDevGetFileInformation;
+  dokanOperations->FindFiles = MirrorDevFindFiles;
+  dokanOperations->GetVolumeInformationW = MirrorDevGetVolumeInformation;
+}
+
+int MirrorDevInit(enum MirrorDevFileType type,
+  LPWSTR PhysicalDrive, PDOKAN_OPTIONS Options, PDOKAN_OPERATIONS Operations)
+{
+  struct MirrorDevData &devData = g_MirrorDevData;
+  int rc;
+  devData.SetType(type);
+  MirrorDevFillOptions(Options);
+  MirrorDevFillOperations(Operations);
+  devData.mirrorDevPhysDevHandle = CreateFile(PhysicalDrive,
+    GENERIC_READ,
+    FILE_SHARE_READ | FILE_SHARE_WRITE,
+    NULL, OPEN_EXISTING, 0, 0);
+
+  if (devData.mirrorDevPhysDevHandle == INVALID_HANDLE_VALUE) {
+    DbgPrint(L"Failed to open drive %s\n", PhysicalDrive);
+    rc = -1;
+  }
+  else {
+    LARGE_INTEGER size;
+    rc = GetMirrorBackingDevSize(&size);
+    if (rc == 0) {
+      devData.devSizeInBlocks = size.QuadPart / devData.MirrorDevBlockSize();
+      struct VHD_VHDX_IF *virt = NULL;
+
+      if (type == MirrorDevTypeVHD) {
+        virt = new VHD(512); // TODO: what should required alignment be for VHD?
+      }
+      else if (type == MirrorDevTypeVHDX) {
+        virt = new VHDX();
+      }
+      if (virt != NULL) {
+        FILE_END_OF_FILE_INFO eof_info;
+        DbgPrint(L"Construct header for type %d\n", type);
+        virt->ConstructHeader(size.QuadPart, 0, devData.MirrorDevBlockSize(), true, eof_info);
+        DbgPrint(L"Write footer to buffer\n");
+        virt->WriteFooterToBuffer(devData.footer);
+        DbgPrint(L"Footer length %d bytes\n", devData.footer.size());
+        DbgPrint(L"Write header to buffer\n");
+        virt->WriteHeaderToBuffer(devData.header);
+        DbgPrint(L"Header length %d bytes first 4 bytes 0x%02x%02x%02x%02x\n",
+          devData.header.size(),
+          devData.header.size() >= 4 ? devData.header[0] : 0,
+          devData.header.size() >= 4 ? devData.header[1] : 0,
+          devData.header.size() >= 4 ? devData.header[2] : 0,
+          devData.header.size() >= 4 ? devData.header[3] : 0
+          );
+
+
+        delete virt;
+        virt = NULL;
+      }
+    }
+  }
+
+
+  return rc == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+void MirrorDevTeardown()
+{
+  if (GetMirrorDevHandle() != INVALID_HANDLE_VALUE)
+  {
+    CloseHandle(GetMirrorDevHandle());
+  }
+}
+
+/**
+* Rename this wmain to test read operations in isolation.
+* TODO: Should replace this with an actual test case
+*/
+#if MIRROR_DEV_MAIN
+int __cdecl wmain2(ULONG argc, PWCHAR argv[]) {
+  g_DebugMode = TRUE;
+  g_UseStdErr = TRUE;
+  g_MirrorDevHandle = CreateFile(L"\\\\.\\PhysicalDrive1",
+    GENERIC_READ,
+    FILE_SHARE_READ | FILE_SHARE_WRITE,
+    NULL, OPEN_EXISTING, 0, 0);
+
+  if (g_MirrorDevHandle == INVALID_HANDLE_VALUE)
+  {
+    DbgPrint(L"CreateFile failed with error %d\n", GetLastError());
+  }
+  LONGLONG Offset = 528;
+  DWORD offsetRemainder=0;
+  DWORD ReadLengthDword;
+  UCHAR Buffer[512];
+  DWORD BufferLength = 512;
+  DWORD ReadLength = BufferLength;
+
+  if (MirrorDevSeekAligned(Offset, &offsetRemainder))
+  {
+    DbgPrint(L"Seek completed successfully to offset %u with remainder %u bytes\n", Offset, offsetRemainder);
+    if (MirrorDevReadAligned(offsetRemainder, Buffer, ReadLength, &ReadLengthDword))
+    {
+      DbgPrint(L"Read %lu bytes from device, first first 4 bytes 0x%02x%02x%02x%02x\n\n",
+        ReadLengthDword, ((UCHAR *)Buffer)[0], ((UCHAR *)Buffer)[1], ((UCHAR *)Buffer)[2], ((UCHAR *)Buffer)[3]);
+    }
+    else
+    {
+      DbgPrint(L"ReadFile failed with error %d\n", GetLastError());
+    }
+  }
+  else
+  {
+    DbgPrint(L"Seek failed with error %d\n", GetLastError());
+  }
+  return 0;
+
+}
+#endif

--- a/samples/dokan_mirror/mirror_dev.h
+++ b/samples/dokan_mirror/mirror_dev.h
@@ -43,6 +43,13 @@ extern "C" {
   void MirrorDevTeardown();
   void DbgPrint(LPCWSTR format, ...);
 
+  static wchar_t *g_MirrorDevDokanPathPrefix = L"\\MIRROR";
+  static size_t g_MirrorDevDokanPathPrefixLength = 8;
+  static wchar_t *g_MirrorDevDokanVhdPostfix = L".VHD";
+  static size_t g_MirrorDevDokanVhdPostfixLength = 4;
+  static wchar_t *g_MirrorDevDokanVhdxPostfix = L".VHDX";
+  static size_t g_MirrorDevDokanVhdxPostfixLength = 5;
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/dokan_mirror/mirror_dev.h
+++ b/samples/dokan_mirror/mirror_dev.h
@@ -1,0 +1,48 @@
+#pragma once
+#include "../../dokan/dokan.h"
+
+//#define WIN10_ENABLE_LONG_PATH
+#ifdef WIN10_ENABLE_LONG_PATH
+//dirty but should be enough
+#define DOKAN_MAX_PATH 32768
+#else
+#define DOKAN_MAX_PATH MAX_PATH
+#endif // DEBUG
+
+#define MirrorCheckFlag(val, flag)                                             \
+  if (val & flag) {                                                            \
+    DbgPrint(L"\t" L#flag L"\n");                                              \
+  }
+
+extern BOOL g_UseStdErr;
+extern BOOL g_DebugMode;
+
+enum MirrorDevFileType
+{
+  /**
+  * Expose the drive as a raw file in the filesystem
+  */
+  MirrorDevTypeRawFile=0,
+  /**
+  * Expose the drive as a .vhd file in the filesystem
+  */
+  MirrorDevTypeVHD,
+  /**
+  * Expose the drive as a .vhdx file in the filesystem
+  */
+  MirrorDevTypeVHDX
+};
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  int MirrorDevInit(enum MirrorDevFileType type,
+    LPWSTR PhysicalDrive, PDOKAN_OPTIONS DokanOptions, PDOKAN_OPERATIONS DokanOperations);
+  void MirrorDevTeardown();
+  void DbgPrint(LPCWSTR format, ...);
+
+#ifdef __cplusplus
+}
+#endif

--- a/samples/dokan_mirror/vhd.c
+++ b/samples/dokan_mirror/vhd.c
@@ -1,0 +1,200 @@
+﻿/*
+Dokan : user-mode file system library for Windows
+
+Copyright (C) 2015 - 2017 Adrien J. <liryna.stark@gmail.com> and Maxime C. <maxime@islog.com>
+Copyright (C) 2007 - 2011 Hiroki Asakawa <info@dokan-dev.net>
+
+http://dokan-dev.github.io
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "../../dokan/dokan.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <winbase.h>
+#include <stdbool.h>
+
+#include "vhd.h"
+#include "mirror_dev.h"
+
+#define VHD_SECTOR_SIZE 512
+
+
+#define is_power_of_2(value)\
+  (value && (value & (value - 1)) == 0)
+
+const UINT64 VHD_COOKIE = 0x78697463656e6f63;
+const UINT32 VHD_VERSION = 0x10000;
+const UINT64 VHD_MAX_DISK_SIZE = 2040ULL * 1024 * 1024 * 1024;
+const UINT32 VHD_TYPE_FIXED = 2;
+const UINT64 VHD_INVALID_OFFSET = 0xFFFFFFFFFFFFFFFFULL;
+
+struct VHD_FOOTER
+{
+  UINT64 Cookie;
+  UINT32 Features;
+  UINT32 FileFormatVersion;
+  UINT64 DataOffset;
+  UINT32 TimeStamp;
+  UINT32 CreatorApplication;
+  UINT32 CreatorVersion;
+  UINT32 CreatorHostOS;
+  UINT64 OriginalSize;
+  UINT64 CurrentSize;
+  UINT32 DiskGeometry;
+  UINT32 DiskType;
+  UINT32 Checksum;
+  GUID   UniqueId;
+  UINT8  SavedState;
+  UINT8  Reserved[427];
+};
+
+
+
+static UINT8 *VHDToBigEndianByteBuffer(UINT8 *buffer, UINT64 value, UINT8 len_bytes)
+{
+  int i = 0;
+  for (i = 0; i < len_bytes; i++) {
+    *buffer = (UINT8) (value >> (64-((8 - (len_bytes-i-1)) * 8)));
+    buffer++;
+  }
+  return buffer;
+}
+
+static void VHDFooterToBuffer(BYTE* buffer, const struct VHD_FOOTER *footer)
+{
+  BYTE *bufferOffs = buffer;
+  memset(bufferOffs, 0, VHD_FOOTER_SIZE);
+  memcpy(bufferOffs, &footer->Cookie, sizeof(footer->Cookie));
+  bufferOffs += sizeof(footer->Cookie);
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->Features, sizeof(footer->Features));
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->FileFormatVersion, sizeof(footer->FileFormatVersion));
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->DataOffset, sizeof(footer->DataOffset));
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->TimeStamp, sizeof(footer->TimeStamp));
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->CreatorApplication, sizeof(footer->CreatorApplication));
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->CreatorVersion, sizeof(footer->CreatorVersion));
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->CreatorHostOS, sizeof(footer->CreatorHostOS));
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->OriginalSize, sizeof(footer->OriginalSize));
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->CurrentSize, sizeof(footer->CurrentSize));
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->DiskGeometry, sizeof(footer->DiskGeometry));
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->DiskType, sizeof(footer->DiskType));
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->Checksum, sizeof(footer->Checksum));
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->UniqueId.Data1, sizeof(footer->UniqueId.Data1));
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->UniqueId.Data2, sizeof(footer->UniqueId.Data2));
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->UniqueId.Data3, sizeof(footer->UniqueId.Data3));
+  memcpy(bufferOffs, footer->UniqueId.Data4, sizeof(footer->UniqueId.Data4));
+  bufferOffs += sizeof(footer->UniqueId.Data4);
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->UniqueId.Data3, sizeof(footer->UniqueId.Data3));
+  bufferOffs = VHDToBigEndianByteBuffer(bufferOffs, footer->SavedState, sizeof(footer->SavedState));
+}
+
+
+UINT32 VHDChecksumUpdate(struct VHD_FOOTER* footer)
+{
+  footer->Checksum = 0;
+  struct VHD_FOOTER_BUFFER driveFooter;
+  VHDFooterToBuffer(&driveFooter.Byte[0], footer);
+  UINT32 checksum = 0;
+  for (UINT32 counter = 0; counter < sizeof(driveFooter.Byte); counter++)
+  {
+    checksum += driveFooter.Byte[counter];
+  }
+  return footer->Checksum = (~checksum);
+}
+
+UINT32 CHSCalculate(UINT64 disk_size)
+{
+  UINT64 totalSectors = disk_size / VHD_SECTOR_SIZE;
+  UINT32 cylinderTimesHeads;
+  UINT16 cylinders;
+  UINT8  heads;
+  UINT8  sectorsPerTrack;
+  if (totalSectors > 65535 * 16 * 255)
+  {
+    totalSectors = 65535 * 16 * 255;
+  }
+  if (totalSectors >= 65535 * 16 * 63)
+  {
+    sectorsPerTrack = 255;
+    heads = 16;
+    cylinderTimesHeads = (UINT32)(totalSectors / sectorsPerTrack);
+  }
+  else
+  {
+    sectorsPerTrack = 17;
+    cylinderTimesHeads = (UINT32)(totalSectors / sectorsPerTrack);
+    heads = (UINT8)((cylinderTimesHeads + 1023) / 1024);
+    if (heads < 4)
+    {
+      heads = 4;
+    }
+    if (cylinderTimesHeads >= (heads * 1024U) || heads > 16)
+    {
+      sectorsPerTrack = 31;
+      heads = 16;
+      cylinderTimesHeads = (UINT32)(totalSectors / sectorsPerTrack);
+    }
+    if (cylinderTimesHeads >= (heads * 1024U))
+    {
+      sectorsPerTrack = 63;
+      heads = 16;
+      cylinderTimesHeads = (UINT32)(totalSectors / sectorsPerTrack);
+    }
+  }
+  cylinders = (UINT16)(cylinderTimesHeads / heads);
+  return (cylinders << 16 | heads << 8 | sectorsPerTrack);
+}
+
+bool VHDFillFooter(struct VHD_FOOTER *footer, UINT64 disk_size)
+{
+  bool success = true;
+  memset(footer, 0, sizeof(struct VHD_FOOTER));
+  footer->Cookie = VHD_COOKIE;
+  footer->Features = 2;
+  footer->FileFormatVersion = VHD_VERSION;
+  footer->DataOffset = VHD_INVALID_OFFSET;
+  footer->OriginalSize = disk_size;
+  footer->CurrentSize = disk_size;
+  footer->DiskGeometry = CHSCalculate(disk_size);
+  footer->DiskType = VHD_TYPE_FIXED;
+  if (CoCreateGuid(&footer->UniqueId) != S_OK) {
+    DbgPrint(L"Failed to create Guid");
+    success = false;
+  }
+  VHDChecksumUpdate(footer);
+  return success;
+}
+
+
+bool VHDFillFixedHeaderSector(struct VHD_FOOTER_BUFFER *buffer, UINT32 block_size, UINT64 disk_size)
+{
+  struct VHD_FOOTER vhd_footer;
+  bool success = false;
+
+  if (block_size == 0 || !is_power_of_2(block_size)) {
+    DbgPrint(L"Invalid block size %d\n", block_size);
+  }
+  else if (VHDFillFooter(&vhd_footer, disk_size)) {
+    VHDFooterToBuffer(&buffer->Byte[0], &vhd_footer);
+    success = true;
+  }
+
+  return success;
+}

--- a/samples/dokan_mirror/vhd.h
+++ b/samples/dokan_mirror/vhd.h
@@ -1,0 +1,61 @@
+﻿/*
+Dokan : user-mode file system library for Windows
+
+Copyright (C) 2015 - 2017 Adrien J. <liryna.stark@gmail.com> and Maxime C. <maxime@islog.com>
+Copyright (C) 2007 - 2011 Hiroki Asakawa <info@dokan-dev.net>
+
+http://dokan-dev.github.io
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+This file contains vhd format code based on the Zero Copy VHD Converter at
+https://github.com/0xbadfca11/makevhdx with license:
+
+MIT License
+
+Copyright (c) 2017 鈴木友紀
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#pragma once
+
+#define VHD_FOOTER_SIZE 512
+#define VHD_ALIGNMENT_BYTES (8*512)
+struct VHD_FOOTER_BUFFER
+{
+  UINT8 Byte[VHD_FOOTER_SIZE];
+};
+
+bool VHDFillFixedHeaderSector(struct VHD_FOOTER_BUFFER *buffer, UINT32 block_size, UINT64 disk_size);


### PR DESCRIPTION
### Changes proposed in this pull request:

This merge request exist like result of implementing issue https://github.com/dokan-dev/dokany/issues/627.
There added full logic to creating VHD(X) disk images on file system with possibility to use auto attaching them in Windows file system.
It can be used for hardware encrypted disks that after sign in operation need show if system like usual disk. It's useful feature for such cases. For now, attached disk has READ ONLY access. Access for writing planing add in near future.
Solution was tested on Windows 10, Windows SDK 10.0.17134.0 and 10.0.16299.0.
See example of use:

```
mirror.exe /P \\.\PhysicalDrive3 /l C:\testMirror /e /x
/P - drive name
/l - folder for mirroring
/e - auto attach to file system as virtual drive
/x - make VHDX disk
```

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [x] I have updated the change log (Add/Change/Fix)
- [x] I have cleaned up the commit history (use rebase and squash)
