### PR TITLE
Kernel - Force unmount after multiple consecutive timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 ### Changed
 - Cert - Runs with admin rights and checks Secureboot is enabled
+- Kernel - Force unmount after multiple consecutive timeout
 
 ### Fixed
 

--- a/sys/device.c
+++ b/sys/device.c
@@ -987,6 +987,7 @@ Return Value:
       DDbgPrint("  IOCTL_KEEPALIVE\n");
       if (IsFlagOn(vcb->Flags, VCB_MOUNTED)) {
         ExEnterCriticalRegionAndAcquireResourceExclusive(&dcb->Resource);
+        dcb->KeepaliveCount = 0;
         DokanUpdateTimeout(&dcb->TickCount, DOKAN_KEEPALIVE_TIMEOUT);
         ExReleaseResourceAndLeaveCriticalRegion(&dcb->Resource);
         status = STATUS_SUCCESS;

--- a/sys/dokan.h
+++ b/sys/dokan.h
@@ -97,6 +97,7 @@ extern LOOKASIDE_LIST_EX g_DokanEResourceLookasideList;
 #define DOKAN_CHECK_INTERVAL (1000 * 5)                     // in millisecond
 
 #define DOKAN_KEEPALIVE_TIMEOUT (1000 * 15) // in millisecond
+#define DOKAN_KEEPALIVE_COUNT_MAX 3
 
 #if _WIN32_WINNT > 0x501
 
@@ -253,6 +254,7 @@ typedef struct _DokanDiskControlBlock {
   ULONG MountId;
   ULONG Flags;
   LARGE_INTEGER TickCount;
+  USHORT KeepaliveCount;
 
   CACHE_MANAGER_CALLBACKS CacheManagerCallbacks;
   CACHE_MANAGER_CALLBACKS CacheManagerNoOpCallbacks;

--- a/sys/fscontrol.c
+++ b/sys/fscontrol.c
@@ -641,6 +641,7 @@ NTSTATUS DokanMountVolume(__in PDEVICE_OBJECT DiskDevice, __in PIRP Irp) {
 
   // Start check thread
   ExAcquireResourceExclusiveLite(&dcb->Resource, TRUE);
+  dcb->KeepaliveCount = 0;
   DokanUpdateTimeout(&dcb->TickCount, DOKAN_KEEPALIVE_TIMEOUT * 3);
   ExReleaseResourceLite(&dcb->Resource);
   DokanStartCheckThread(dcb);

--- a/sys/timeout.c
+++ b/sys/timeout.c
@@ -94,6 +94,10 @@ VOID DokanCheckKeepAlive(__in PDokanDCB Dcb) {
   ExAcquireResourceSharedLite(&Dcb->Resource, TRUE);
 
   if (Dcb->TickCount.QuadPart < tickCount.QuadPart) {
+    Dcb->KeepaliveCount += 1;
+  }
+
+  if (Dcb->KeepaliveCount >= DOKAN_KEEPALIVE_COUNT_MAX) {
 
     vcb = Dcb->Vcb;
 


### PR DESCRIPTION
Fixes #634 #692 .

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [x] I have updated the change log (Add/Change/Fix)
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- DokanCheckKeepAlive keeps a count of consecutive timeout detected in dcb->KeepaliveCount .
- DokanCheckKeepAlive forces unmount only if dcb->KeepaliveCount reaches DOKAN_KEEPALIVE_COUNT_MAX (3)
