### PR TITLE
sys - The szMountPoint->length should be the byte length.

### DIFF
--- a/sys/notification.c
+++ b/sys/notification.c
@@ -543,7 +543,7 @@ NTSTATUS DokanGlobalEventRelease(__in PDEVICE_OBJECT DeviceObject,
     dokanControl.MountPoint[13] = L':';
     dokanControl.MountPoint[14] = L'\0';
   } else {
-    if (szMountPoint->Length + 12 > MAX_PATH) {
+    if ((szMountPoint->Length / sizeof(WCHAR) + 12) > MAX_PATH) {
       DDbgPrint("Montpoint Buffer has an invalid size\n");
       return STATUS_BUFFER_OVERFLOW;
 	}


### PR DESCRIPTION
During reviewing the security fix for buffer overflow issue. I found the fix may cause other issue. The szMountPoint->length is used as string length but not byte length.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Div sizeof(WCHAR) before comparing with MAX_PATH

