### PR TITLE
Increase max thread count from 15 to 63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- Increase DOKAN_MAX_THREAD from 15 to 63 for better performance.
 
 ## [1.2.1.2000] - 2018-12-21
 ### Added

--- a/dokan/dokanc.h
+++ b/dokan/dokanc.h
@@ -44,7 +44,7 @@ extern "C" {
 
 #define DOKAN_KEEPALIVE_TIME 3000 // in miliseconds
 
-#define DOKAN_MAX_THREAD 15
+#define DOKAN_MAX_THREAD 63
 
 // DokanOptions->DebugMode is ON?
 extern BOOL g_DebugMode;


### PR DESCRIPTION
### Change proposed
The limit of 15 dispatcher threads reduces throughput when the client is employing high parallelism, for example by running `robocopy /mt:50`. I have tested with up to 63 threads with significant stress and everything seems to be running fine. For values 64 or higher, I ran into trouble, so I stopped at 63 for now.

Also note that the [Google Drive fork](https://github.com/google/google-drive-dokany/blob/master/src/dokan/dokanc.h#L52) of Dokan has this increased to 50.

Changing this limit does not change the default - it only allows code to specify something higher than 15.

### Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the existing documentation
- [X] My changes generate no new warnings
- [X] I have updated the change log (Add/Change/Fix)
- [X] I have cleaned up the commit history (use rebase and squash)
