### PR TITLE
Library - Use DbgPrintW instead of DbgPrint when printing wide characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Library - Use `DbgPrintW` instead of `DbgPrint` when printing wide characters
+
 ## [1.2.2.1000] - 2019-03-08
 ### Added
 - FUSE - Expose allocation unit size and sector size.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Fixed
 - Library - Use `DbgPrintW` instead of `DbgPrint` when printing wide characters
+- Library - Add error check for `_vscprintf` and `vsprintf_s` in `DokanDbgPrint`, and `_vscwprintf` and `vswprintf_s` in `DokanDbgPrintW`
 
 ## [1.2.2.1000] - 2019-03-08
 ### Added

--- a/dokan/dokan.c
+++ b/dokan/dokan.c
@@ -388,8 +388,8 @@ UINT WINAPI DokanLoop(PVOID pDokanInstance) {
                    );
 
     if (device == INVALID_HANDLE_VALUE) {
-      DbgPrint(
-          "Dokan Error: CreateFile failed %ws: %d\n",
+      DbgPrintW(
+          L"Dokan Error: CreateFile failed %s: %d\n",
           GetRawDeviceName(DokanInstance->DeviceName, rawDeviceName, MAX_PATH),
           GetLastError());
       free(buffer);
@@ -632,12 +632,12 @@ BOOL SendReleaseIRP(LPCWSTR DeviceName) {
   ULONG returnedLength;
   WCHAR rawDeviceName[MAX_PATH];
 
-  DbgPrint("send release to %ws\n", DeviceName);
+  DbgPrintW(L"send release to %s\n", DeviceName);
 
   if (!SendToDevice(GetRawDeviceName(DeviceName, rawDeviceName, MAX_PATH),
                     IOCTL_EVENT_RELEASE, NULL, 0, NULL, 0, &returnedLength)) {
 
-    DbgPrint("Failed to unmount device:%ws\n", DeviceName);
+    DbgPrintW(L"Failed to unmount device:%s\n", DeviceName);
     return FALSE;
   }
 
@@ -659,13 +659,13 @@ BOOL SendGlobalReleaseIRP(LPCWSTR MountPoint) {
         szMountPoint->Length = (USHORT)(length * sizeof(WCHAR));
         CopyMemory(szMountPoint->Buffer, MountPoint, szMountPoint->Length);
 
-        DbgPrint("send global release for %ws\n", MountPoint);
+        DbgPrintW(L"send global release for %s\n", MountPoint);
 
         if (!SendToDevice(DOKAN_GLOBAL_DEVICE_NAME, IOCTL_EVENT_RELEASE,
                           szMountPoint, inputLength, NULL, 0,
                           &returnedLength)) {
 
-          DbgPrint("Failed to unmount: %ws\n", MountPoint);
+          DbgPrintW(L"Failed to unmount: %s\n", MountPoint);
           free(szMountPoint);
           return FALSE;
         }
@@ -768,7 +768,7 @@ BOOL SendToDevice(LPCWSTR DeviceName, DWORD IoControlCode, PVOID InputBuffer,
 
   if (device == INVALID_HANDLE_VALUE) {
     DWORD dwErrorCode = GetLastError();
-    DbgPrint("Dokan Error: Failed to open %ws with code %d\n", DeviceName,
+    DbgPrintW(L"Dokan Error: Failed to open %s with code %d\n", DeviceName,
              dwErrorCode);
     return FALSE;
   }

--- a/dokan/dokanc.h
+++ b/dokan/dokanc.h
@@ -55,19 +55,20 @@ extern BOOL g_UseStdErr;
 #ifdef _MSC_VER
 
 static VOID DokanDbgPrint(LPCSTR format, ...) {
-  const char *outputString;
-  char *buffer;
-  size_t length;
+  const char *outputString = format;    // fallback
+  char *buffer = NULL;
+  int length;
   va_list argp;
 
   va_start(argp, format);
   length = _vscprintf(format, argp) + 1;
-  buffer = (char *)_malloca(length * sizeof(char));
+  if ((length - 1) != -1) {
+    buffer = (char *)_malloca(length * sizeof(char));
+  }
   if (buffer) {
-    vsprintf_s(buffer, length, format, argp);
-    outputString = buffer;
-  } else {
-    outputString = format;
+    if (vsprintf_s(buffer, length, format, argp) != -1) {
+      outputString = buffer;
+    }
   }
   if (g_UseStdErr)
     fputs(outputString, stderr);
@@ -81,19 +82,20 @@ static VOID DokanDbgPrint(LPCSTR format, ...) {
 }
 
 static VOID DokanDbgPrintW(LPCWSTR format, ...) {
-  const WCHAR *outputString;
-  WCHAR *buffer;
-  size_t length;
+  const WCHAR *outputString = format;   // fallback
+  WCHAR *buffer = NULL;
+  int length;
   va_list argp;
 
   va_start(argp, format);
   length = _vscwprintf(format, argp) + 1;
-  buffer = (WCHAR *)_malloca(length * sizeof(WCHAR));
+  if ((length - 1) != -1) {
+    buffer = (WCHAR *)_malloca(length * sizeof(WCHAR));
+  }
   if (buffer) {
-    vswprintf_s(buffer, length, format, argp);
-    outputString = buffer;
-  } else {
-    outputString = format;
+    if (vswprintf_s(buffer, length, format, argp) != -1) {
+      outputString = buffer;
+    }
   }
   if (g_UseStdErr)
     fputws(outputString, stderr);


### PR DESCRIPTION
Made a change in dokan1.dll userspace library.
Fixes #787.

### Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [x] I have updated the change log (Add/Change/Fix)
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Library - Use `DbgPrintW` instead of `DbgPrint` when printing wide characters
- Library - Add error check for `_vscprintf` and `vsprintf_s` in `DokanDbgPrint`, and `_vscwprintf` and `vswprintf_s` in `DokanDbgPrintW`
