### PR TITLE
Small documentation fix... 

### DIFF
--- a/dokan/dokan.h
+++ b/dokan/dokan.h
@@ -615,7 +615,7 @@ typedef struct _DOKAN_OPERATIONS {
   *
   * \param DokanFileInfo Information about the file or directory.
   * \return \c STATUS_SUCCESS on success or \c NTSTATUS appropriate to the request result.
-  * \see Unmounted
+  * \see Mounted
   */
   NTSTATUS(DOKAN_CALLBACK *Unmounted)(PDOKAN_FILE_INFO DokanFileInfo);
 


### PR DESCRIPTION
where Unmounted() operation should reference Mounted() operation and not itself

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [x] I have updated the change log (Add/Change/Fix)
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
In the documentation of the Unmounted() callback the corresponding _other_ method (Mounted()) is referenced.