### PR TITLE
Add build and vars scripts to support building with sonarqube analysis

### DIFF
--- a/sonarbuild.bat
+++ b/sonarbuild.bat
@@ -1,0 +1,150 @@
+@echo off
+setlocal ENABLEDELAYEDEXPANSION
+REM Build release to prepare for packaging
+
+REM Make sure MSBUILD is available
+REM (the -sort option reverses the sort order. If/when dokany moves to VS2019, this will need to be changed.  The logic will need to be revisited when a VS version later than 2019 comes out.)
+FOR /f "delims=" %%A IN (
+	'"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -property installationPath -sort'
+) DO SET "VS_PATH=%%A"
+
+SET MSBUILD_BIN_PATH="%VS_PATH%\MSBuild\15.0\Bin"
+IF NOT EXIST "%VS_PATH%" (
+	ECHO Visual C++ 2017 NOT Installed.
+	PAUSE
+	EXIT /B
+)
+
+rem This is where you should set the environment variables needed for integration with SonarQube.
+IF EXIST "sonarvars.bat" (
+	CALL sonarvars.bat
+)
+
+rem Seriously, the space after the openparen must be there to separate the tokens, and there must be no space between the end of the SET values and the closeparen. Otherwise, the trailing space
+rem gets put into the value of the environment variable being set, which causes all the string equality tests to fail.
+IF NOT "%SONARBUILD%"=="" ( SET shouldsonar=true)	
+IF NOT "%SONAR_KEY%"==""  ( SET shouldsonar=true)
+IF NOT "%shouldsonar%"=="true" goto skipsonar 
+	ECHO Building using SonarBuild. Environment variables which must be set are:
+	ECHO SONAR_KEY:				The parameter to /k: for user-space components (%SONAR_KEY%)
+	ECHO SONAR_KEY_SYS:			The parameter to /k: for kernel-mode components (%SONAR_KEY_SYS%)
+	ECHO SONAR_LOGIN:			The parameter to /d:sonar.login= (%SONAR_LOGIN%)
+	ECHO SONAR_ORGANIZATION:	The parameter to /d:sonar.organization= (%SONAR_ORGANIZATION%)
+	ECHO SONAR_HOST_URL:		The parameter to /d:sonar.host.url= (%SONAR_HOST_URL%)
+	ECHO Also, both the Build Wrapper for Windows and Scanner for MSBuild must be located in the PATH.
+	SET SONAR_CFAMILY_BUILDWRAPPEROUTPUT=bw-output
+	SET SONAR_WRAPPER=build-wrapper-win-x86-64.exe
+	SET BUILD_WRAPPER=!SONAR_WRAPPER! --out-dir !SONAR_CFAMILY_BUILDWRAPPEROUTPUT!
+	SET SONAR_SCANNER=SonarScanner.MSBuild.exe
+
+
+	where /q %SONAR_WRAPPER%
+	if ERRORLEVEL 1 ( 
+		echo Cannot find the build wrapper %SONAR_WRAPPER%
+		set BUILD_WRAPPER=)
+	where /q %SONAR_SCANNER%
+	if ERRORLEVEL 1 (
+		echo Cannot find the Sonar Scanner %SONAR_SCANNER%
+		set BUILD_WRAPPER=)
+	
+	if "%SONAR_KEY%"=="" ( set BUILD_WRAPPER=)
+	if "%SONAR_LOGIN%"=="" ( set BUILD_WRAPPER=)
+	if "%SONAR_ORGANIZATION%"=="" ( set BUILD_WRAPPER=)
+	if "%SONAR_HOST_URL%"=="" ( set BUILD_WRAPPER=)
+	IF "%BUILD_WRAPPER%"=="" (
+		echo Proceeding WITHOUT SonarQube analysis
+	)
+	if NOT "%BUILD_WRAPPER%"=="" (
+		echo Everything looks good. SonarQube analysis is enabled for this build.
+	)
+rem Clean up after ourselves
+	SET shouldsonar=
+	
+:skipsonar
+
+set PATH=%PATH%;%MSBUILD_BIN_PATH%
+
+REM Enable AppVeyor build message logging if running under AppVeyor
+IF "%APPVEYOR%"=="True" set CI_BUILD_ARG="/l:C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+REM Set up SonarQube user-mode analysis if BUILD_WRAPPER environment variable set
+IF NOT "%BUILD_WRAPPER%"=="" (
+	%SONAR_SCANNER% begin /k:"%SONAR_KEY%" /d:sonar.login="%SONAR_LOGIN%" /d:sonar.organization="%SONAR_ORGANIZATION%" /d:sonar.host.url="%SONAR_HOST_URL%" /d:sonar.cfamily.build-wrapper-output=!SONAR_CFAMILY_BUILDWRAPPEROUTPUT!
+)
+REM Build
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration=Release;Platform=x64 /t:Rebuild !CI_BUILD_ARG! || goto buildfailed
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration=Release;Platform=Win32 /t:Rebuild !CI_BUILD_ARG! || goto buildfailed
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration=Release;Platform=ARM /t:Rebuild !CI_BUILD_ARG! || goto buildfailed
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration=Release;Platform=ARM64 /t:Rebuild !CI_BUILD_ARG! || goto buildfailed
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration=Debug;Platform=x64 /t:Rebuild !CI_BUILD_ARG! || goto buildfailed
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration=Debug;Platform=Win32 /t:Rebuild !CI_BUILD_ARG! || goto buildfailed
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration=Debug;Platform=ARM /t:Rebuild !CI_BUILD_ARG! || goto buildfailed
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration=Debug;Platform=ARM64 /t:Rebuild !CI_BUILD_ARG! || goto buildfailed
+goto usermodedone
+
+:buildfailed
+SET failedERROR=%ERRORLEVEL%
+SET buildfailed=true
+
+:usermodedone
+REM End user-space wrapper
+IF NOT "%BUILD_WRAPPER%"=="" (
+	%SONAR_SCANNER% end /d:sonar.login="%SONAR_LOGIN%"
+)
+
+IF "%buildfailed%"=="true" ( goto buildfailed)
+
+
+REM Set up SonarQube kernel-mode analysis if SONAR_KEY_SYS environment variable set
+IF NOT "%BUILD_WRAPPER%"=="" (
+	IF NOT "%SONAR_KEY_SYS%"=="" (
+		%SONAR_SCANNER% begin /k:"%SONAR_KEY_SYS%" /d:sonar.login="%SONAR_LOGIN%" /d:sonar.organization="%SONAR_ORGANIZATION%" /d:sonar.host.url="%SONAR_HOST_URL%" /d:sonar.cfamily.build-wrapper-output=!SONAR_CFAMILY_BUILDWRAPPEROUTPUT!
+	)
+)
+
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win10 Release";Platform=x64 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win10 Release";Platform=Win32 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win10 Release";Platform=ARM /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win10 Release";Platform=ARM64 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win7 Release";Platform=x64 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win7 Release";Platform=Win32 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win8 Release";Platform=x64 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win8 Release";Platform=Win32 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win8 Release";Platform=ARM /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win8.1 Release";Platform=x64 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win8.1 Release";Platform=Win32 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win8.1 Release";Platform=ARM /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win7 Debug";Platform=x64 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win7 Debug";Platform=Win32 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win8 Debug";Platform=x64 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win8 Debug";Platform=Win32 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win8 Debug";Platform=ARM /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win8.1 Debug";Platform=x64 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win8.1 Debug";Platform=Win32 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win8.1 Debug";Platform=ARM /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win10 Debug";Platform=x64 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win10 Debug";Platform=Win32 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win10 Debug";Platform=ARM /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+%BUILD_WRAPPER% msbuild dokan.sln /p:Configuration="Win10 Debug";Platform=ARM64 /t:Rebuild !CI_BUILD_ARG! || goto buildfailedsys
+:buildfailedsys
+set failedERROR=%ERRORLEVEL%
+set buildfailed=true
+
+REM Finish SonarQube analysis, if BUILD_WRAPPER environment variable is set
+IF NOT "%BUILD_WRAPPER%"=="" (
+	%SONAR_SCANNER% end /d:sonar.login="%SONAR_LOGIN%"
+)
+	
+IF EXIST C:\cygwin64 ( Powershell.exe -executionpolicy remotesigned -File dokan_fuse/build.ps1 || goto buildfailed ) ELSE ( echo "Cygwin/Msys2 build disabled" )
+goto end
+
+:buildfailed
+
+@if !failed! neq 0 (
+    echo A build-command failed.
+	echo The command that failed returned with error !failedERROR! 1>&2
+    exit /b !failedERROR!
+)
+
+:end
+ENDLOCAL

--- a/sonarvars.bat
+++ b/sonarvars.bat
@@ -1,0 +1,6 @@
+@echo off
+SET SONAR_KEY=dokany-project-key
+SET SONAR_KEY_SYS=dokany-sys-project-key
+SET SONAR_LOGIN=[generated in the sonarcloud interface]
+SET SONAR_ORGANIZATION=name-of-sonarcloud-organization
+SET SONAR_HOST_URL=https://sonarcloud.io


### PR DESCRIPTION
### Checklist

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the existing documentation
- [X] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [X] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add a new script, based on build.bat, which will run the Sonar Scanner for MSBuild and the Sonar MSBuild Build Wrapper against the build.  I understand that the project itself has a Travis Continuous Integration system set up for it; however, this is for the benefit of individual developers who want to run SonarQube/SonarCloud analysis against their own changes.
- Modify the vswhere.exe command to reverse-sort the Visual Studio versions installed on the system.  I currently have both VS2017 and VS2019 installed; I found out the hard way that this altered the default output of vswhere.exe.  (I would do a simple version specification, but the version specification language available for vswhere breaks the FOR processing.  See https://developercommunity.visualstudio.com/content/problem/556659/vswhereexe-documented-version-range-syntax-is-mang.html for the bug I filed on it.)
- Reorder the build, so that the non-driver builds (both Release and Debug) are in one section and the driver builds (both Release and Debug) are in another.  Also, so that x64 is built before Win32.  This is to work around a SonarQube issue where only the first build is actually processed; this caused the sys/ directory to not show up in the analysis, because it isn't built for the non-OS-version-specific builds.  Building x64 before Win32 is to make it so that the code build that's running on my system is the code that's analyzed, and can be undone if you'd prefer.

If documentation needs to be added to explain what needs to be changed to get it to work (basically, sonarvars.bat needs to be modified to plug in the correct values available from e.g. sonarcloud.io), I'll happily write it.  Also, sonarvars.bat is a separate file so that it can perhaps be added to .gitignore so that secrets don't inadvertently get put in public repositories, while allowing the main logic of the script to be updated as appropriate.