### PR TITLE
Clarify documentation of dokan file-change notification functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 ### Changed
 - Kernel - Only log to event viewer when debug default log is enabled.
-- Clarified documentation of dokan file-change notification functions
+- Library - Clarified documentation of dokan file-change notification functions
 ### Fixed
 - Library - Incorrect call to `legacyKeepAliveThreadIds` `WaitForObject`.
 - Kernel - FileNameInformation - Only concat `UNCName` / `DiskDeviceName` for network devices.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 ### Changed
 - Kernel - Only log to event viewer when debug default log is enabled.
+- Clarified documentation of dokan file-change notification functions
 ### Fixed
 - Library - Incorrect call to `legacyKeepAliveThreadIds` `WaitForObject`.
 - Kernel - FileNameInformation - Only concat `UNCName` / `DiskDeviceName` for network devices.

--- a/dokan/dokan.h
+++ b/dokan/dokan.h
@@ -949,7 +949,7 @@ BOOL DOKANAPI DokanNotifyXAttrUpdate(LPCWSTR FilePath);
  *  supports in-place rename for file/directory within the same parent.
  *
  * \param OldPath Old, absolute path to the file or directory, including the mount-point of the file system.
- * \param NewPath New,absolute path to the file or directory, including the mount-point of the file system.
+ * \param NewPath New, absolute path to the file or directory, including the mount-point of the file system.
  * \param IsDirectory Indicates if the path is a directory.
  * \param IsInSameFolder Indicates if the file or directory have the same parent directory.
  * \return \c TRUE if notification succeeded.

--- a/dokan/dokan.h
+++ b/dokan/dokan.h
@@ -892,18 +892,28 @@ void DOKANAPI DokanMapKernelToUserCreateFileFlags(
 
 /**
  * \defgroup DokanNotify Dokan Notify
- * \brief Dokan User FS file changes notification
+ * \brief Dokan User FS file-change notification
  *
- * User FileSystem can notify Dokan of outside file changes with those functions.
- * Note that all of the file paths passed in to the Notify methods below must
- * include the drive letter, for example "G:<path>".
+ * The application implementing the user file system can notify
+ * the Dokan kernel driver of external file- and directory-changes.
+ *
+ * For example, the mirror application can notify the driver about
+ * changes made in the mirrored directory so that those changes will
+ * be automatically reflected in the implemented mirror file system.
+ *
+ * This requires the FilePath passed to the respective DokanNotify*-functions
+ * to include the absolute path of the changed file including the drive-letter
+ * and the path to the mount point, e.g. "C:\Dokan\ChangedFile.txt".
+ *
+ * These functions SHOULD NOT be called from within the implemented
+ * file system and thus be independent of any Dokan file system operation.
  * @{
  */
 
 /**
  * \brief Notify dokan that a file or a directory has been created.
  *
- * \param FilePath Full path to the file or directory, including mount point.
+ * \param FilePath Absolute path to the file or directory, including the mount-point of the file system.
  * \param IsDirectory Indicates if the path is a directory.
  * \return \c TRUE if notification succeeded.
  */
@@ -912,8 +922,8 @@ BOOL DOKANAPI DokanNotifyCreate(LPCWSTR FilePath, BOOL IsDirectory);
 /**
  * \brief Notify dokan that a file or a directory has been deleted.
  *
- * \param FilePath Full path to the file or directory, including mount point.
- * \param IsDirectory Indicates if the path is a directory.
+ * \param FilePath Absolute path to the file or directory, including the mount-point of the file system.
+ * \param IsDirectory Indicates if the path was a directory.
  * \return \c TRUE if notification succeeded.
  */
 BOOL DOKANAPI DokanNotifyDelete(LPCWSTR FilePath, BOOL IsDirectory);
@@ -921,7 +931,7 @@ BOOL DOKANAPI DokanNotifyDelete(LPCWSTR FilePath, BOOL IsDirectory);
 /**
  * \brief Notify dokan that file or directory attributes have changed.
  *
- * \param FilePath Full path to the file or directory, including mount point.
+ * \param FilePath Absolute path to the file or directory, including the mount-point of the file system.
  * \return \c TRUE if notification succeeded.
  */
 BOOL DOKANAPI DokanNotifyUpdate(LPCWSTR FilePath);
@@ -929,7 +939,7 @@ BOOL DOKANAPI DokanNotifyUpdate(LPCWSTR FilePath);
 /**
  * \brief Notify dokan that file or directory extended attributes have changed.
  *
- * \param FilePath Full path to the file or directory, including mount point.
+ * \param FilePath Absolute path to the file or directory, including the mount-point of the file system.
  * \return \c TRUE if notification succeeded.
  */
 BOOL DOKANAPI DokanNotifyXAttrUpdate(LPCWSTR FilePath);
@@ -938,10 +948,10 @@ BOOL DOKANAPI DokanNotifyXAttrUpdate(LPCWSTR FilePath);
  * \brief Notify dokan that a file or a directory has been renamed. This method
  *  supports in-place rename for file/directory within the same parent.
  *
- * \param OldPath Old path to the file or directory, including mount point.
- * \param NewPath New path to the file or directory, including mount point.
+ * \param OldPath Old, absolute path to the file or directory, including the mount-point of the file system.
+ * \param NewPath New,absolute path to the file or directory, including the mount-point of the file system.
  * \param IsDirectory Indicates if the path is a directory.
- * \param IsInSameFolder Indicates if the file or directory have same parent.
+ * \param IsInSameFolder Indicates if the file or directory have the same parent directory.
  * \return \c TRUE if notification succeeded.
  */
 BOOL DOKANAPI DokanNotifyRename(LPCWSTR OldPath, LPCWSTR NewPath,


### PR DESCRIPTION
### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [x] I have updated the change log (Add/Change/Fix)
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
Clarifies the documentation of the DokanNotify*-functions introduced with version 1.3.0 to prevent incorrect implementations like discussed in https://github.com/dokan-dev/dokan-dotnet/pull/236