### PR TITLE
Log redirection

### DIFF
--- a/dokan/dokan.c
+++ b/dokan/dokan.c
@@ -84,6 +84,9 @@ volatile PDokanMalloc	g_DokanMalloc = NULL;
 volatile PDokanFree		g_DokanFree = NULL;
 volatile PDokanRealloc	g_DokanRealloc = NULL;
 
+volatile PDokanDbgPrint g_PDokanDbgPrint = NULL;
+volatile PDokanDbgPrintW g_PDokanDbgPrintW = NULL;
+
 volatile LONG			g_DokanInitialized = 0;
 
 // TODO NEXT:
@@ -2016,8 +2019,8 @@ DOKAN_API PTP_POOL DOKAN_CALLBACK DokanGetThreadPool() {
 	return threadPool;
 }
 
-void DOKANAPI DokanInit(DOKAN_MEMORY_CALLBACKS *memoryCallbacks) {
-
+void DOKANAPI DokanInit(DOKAN_MEMORY_CALLBACKS* memoryCallbacks, DOKAN_LOG_CALLBACKS* logCallbacks)
+{
 	// ensure 64-bit alignment
 	assert(offsetof(EVENT_INFORMATION, Buffer) % 8 == 0);
 
@@ -2047,6 +2050,19 @@ void DOKANAPI DokanInit(DOKAN_MEMORY_CALLBACKS *memoryCallbacks) {
 		InterlockedExchange((volatile LONG*)&g_DokanRealloc, (LONG)memoryCallbacks->Realloc);
 #else
 #error Unsupported architecture!
+#endif
+	}
+
+	if (logCallbacks)
+	{
+#if INTPTR_MAX == INT64_MAX
+		InterlockedExchange64((volatile LONG64*)&g_PDokanDbgPrint, (LONG64)logCallbacks->DbgPrint);
+		InterlockedExchange64((volatile LONG64*)&g_PDokanDbgPrintW, (LONG64)logCallbacks->DbgPrintW);
+#elif INTPTR_MAX == INT32_MAX
+		InterlockedExchange((volatile LONG*)&g_PDokanDbgPrint, (LONG)logCallbacks->DbgPrint);
+		InterlockedExchange((volatile LONG*)&g_PDokanDbgPrintW, (LONG)logCallbacks->DbgPrintW);
+#else
+		#error Unsupported architecture!
 #endif
 	}
 

--- a/dokan/dokan.c
+++ b/dokan/dokan.c
@@ -2019,8 +2019,7 @@ DOKAN_API PTP_POOL DOKAN_CALLBACK DokanGetThreadPool() {
 	return threadPool;
 }
 
-void DOKANAPI DokanInit(DOKAN_MEMORY_CALLBACKS* memoryCallbacks, DOKAN_LOG_CALLBACKS* logCallbacks)
-{
+void DOKANAPI DokanInit(DOKAN_MEMORY_CALLBACKS* memoryCallbacks, DOKAN_LOG_CALLBACKS* logCallbacks) {
 	// ensure 64-bit alignment
 	assert(offsetof(EVENT_INFORMATION, Buffer) % 8 == 0);
 
@@ -2053,8 +2052,7 @@ void DOKANAPI DokanInit(DOKAN_MEMORY_CALLBACKS* memoryCallbacks, DOKAN_LOG_CALLB
 #endif
 	}
 
-	if (logCallbacks)
-	{
+	if (logCallbacks) {
 #if INTPTR_MAX == INT64_MAX
 		InterlockedExchange64((volatile LONG64*)&g_PDokanDbgPrint, (LONG64)logCallbacks->DbgPrint);
 		InterlockedExchange64((volatile LONG64*)&g_PDokanDbgPrintW, (LONG64)logCallbacks->DbgPrintW);
@@ -2062,7 +2060,7 @@ void DOKANAPI DokanInit(DOKAN_MEMORY_CALLBACKS* memoryCallbacks, DOKAN_LOG_CALLB
 		InterlockedExchange((volatile LONG*)&g_PDokanDbgPrint, (LONG)logCallbacks->DbgPrint);
 		InterlockedExchange((volatile LONG*)&g_PDokanDbgPrintW, (LONG)logCallbacks->DbgPrintW);
 #else
-		#error Unsupported architecture!
+#error Unsupported architecture!
 #endif
 	}
 

--- a/dokan/dokan.h
+++ b/dokan/dokan.h
@@ -227,11 +227,20 @@ typedef void* (WINAPI *PDokanMalloc)(size_t size, const char *fileName, int line
 typedef void (WINAPI *PDokanFree)(void *userData);
 typedef void* (WINAPI *PDokanRealloc)(void *userData, size_t newSize, const char *fileName, int lineNumber);
 
+typedef BOOL (WINAPI *PDokanDbgPrint)(LPCSTR logString);
+typedef BOOL (WINAPI *PDokanDbgPrintW)(LPCWSTR logString);
+
 typedef struct _DOKAN_MEMORY_CALLBACKS {
 	PDokanMalloc	Malloc;
 	PDokanFree		Free;
 	PDokanRealloc	Realloc;
 } DOKAN_MEMORY_CALLBACKS, *PDOKAN_MEMORY_CALLBACKS;
+
+typedef struct _DOKAN_LOG_CALLBACKS
+{
+	PDokanDbgPrint DbgPrint;
+	PDokanDbgPrintW DbgPrintW;
+} DOKAN_LOG_CALLBACKS, *PDOKAN_LOG_CALLBACKS;
 
 #define DOKAN_EXCEPTION_NOT_INITIALIZED			0x0f0ff0ff
 #define DOKAN_EXCEPTION_INITIALIZATION_FAILED	0x0fbadbad
@@ -1102,7 +1111,7 @@ void DOKANAPI DokanEndDispatchSetFileSecurity(DOKAN_SET_FILE_SECURITY_EVENT *Eve
 DOKAN_API PTP_POOL DOKAN_CALLBACK DokanGetThreadPool();
 
 // Init/shutdown
-void DOKANAPI DokanInit(DOKAN_MEMORY_CALLBACKS *memoryCallbacks);
+void DOKANAPI DokanInit(DOKAN_MEMORY_CALLBACKS* memoryCallbacks, DOKAN_LOG_CALLBACKS* logCallbacks);
 void DOKANAPI DokanShutdown();
 /** @} */
 

--- a/dokan/dokanc.h
+++ b/dokan/dokanc.h
@@ -52,6 +52,9 @@ extern BOOL g_DebugMode;
 // DokanOptions->UseStdErr is ON?
 extern BOOL g_UseStdErr;
 
+extern volatile PDokanDbgPrint g_PDokanDbgPrint;
+extern volatile PDokanDbgPrintW g_PDokanDbgPrintW;
+
 #ifdef _MSC_VER
 
 static VOID DokanDbgPrint(LPCSTR format, ...) {
@@ -71,10 +74,18 @@ static VOID DokanDbgPrint(LPCSTR format, ...) {
     outputString = buffer;
   }
 
-  OutputDebugStringA(outputString);
+  BOOL allowStandardPrint = FALSE;
+  if (g_PDokanDbgPrint)
+  {
+	  allowStandardPrint = g_PDokanDbgPrint(outputString);
+  }
+  if (allowStandardPrint)
+  {
+	  OutputDebugStringA(outputString);
+  }
 
-  if(g_UseStdErr) {
-	  
+  if(g_UseStdErr && allowStandardPrint)
+  {  
 	  fputs(outputString, stderr);
 	  fflush(stderr);
   }
@@ -103,10 +114,18 @@ static VOID DokanDbgPrintW(LPCWSTR format, ...) {
     outputString = buffer;
   }
 
-  OutputDebugStringW(outputString);
+  BOOL allowStandardPrint = FALSE;
+  if (g_PDokanDbgPrint)
+  {
+	  allowStandardPrint = g_PDokanDbgPrintW(outputString);
+  }
+  if (allowStandardPrint)
+  {
+	  OutputDebugStringW(outputString);
+  }
 
-  if(g_UseStdErr) {
-
+  if(g_UseStdErr && allowStandardPrint)
+  {
 	  fputws(outputString, stderr);
 	  fflush(stderr);
   }

--- a/dokan/dokanc.h
+++ b/dokan/dokanc.h
@@ -59,6 +59,7 @@ extern volatile PDokanDbgPrintW g_PDokanDbgPrintW;
 
 static VOID DokanDbgPrint(LPCSTR format, ...) {
 
+  BOOL allowStandardPrint = TRUE;
   const char *outputString = format; // fallback
   char *buffer = NULL;
   int length;
@@ -74,18 +75,14 @@ static VOID DokanDbgPrint(LPCSTR format, ...) {
     outputString = buffer;
   }
 
-  BOOL allowStandardPrint = FALSE;
-  if (g_PDokanDbgPrint)
-  {
+  if (g_PDokanDbgPrint) {
 	  allowStandardPrint = g_PDokanDbgPrint(outputString);
   }
-  if (allowStandardPrint)
-  {
+  if (allowStandardPrint) {
 	  OutputDebugStringA(outputString);
   }
 
-  if(g_UseStdErr && allowStandardPrint)
-  {  
+  if(g_UseStdErr && allowStandardPrint) {  
 	  fputs(outputString, stderr);
 	  fflush(stderr);
   }
@@ -99,6 +96,7 @@ static VOID DokanDbgPrint(LPCSTR format, ...) {
 
 static VOID DokanDbgPrintW(LPCWSTR format, ...) {
 
+  BOOL allowStandardPrint = TRUE;
   const WCHAR *outputString = format;   // fallback
   WCHAR *buffer = NULL;
   int length;
@@ -114,24 +112,19 @@ static VOID DokanDbgPrintW(LPCWSTR format, ...) {
     outputString = buffer;
   }
 
-  BOOL allowStandardPrint = FALSE;
-  if (g_PDokanDbgPrint)
-  {
+  if (g_PDokanDbgPrint) {
 	  allowStandardPrint = g_PDokanDbgPrintW(outputString);
   }
-  if (allowStandardPrint)
-  {
+  if (allowStandardPrint) {
 	  OutputDebugStringW(outputString);
   }
 
-  if(g_UseStdErr && allowStandardPrint)
-  {
+  if(g_UseStdErr && allowStandardPrint) {
 	  fputws(outputString, stderr);
 	  fflush(stderr);
   }
 
   if(buffer) {
-
 	  _freea(buffer);
   }
 


### PR DESCRIPTION
Adds log redirection options.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

Currently there is no way to make Dokany log its operation to user-defined target. There is an option to use `stderr` instead of `OutputDebugStringA/W` but that might not be desirable to the library user.

I've added a struct with two function to be provided by the library user that will take formatted debug string and return a `BOOL` value which indicated in Dokany should proceed with its own debug output. The value is `TRUE` by default so in case the used didn't provide any log redirection function the library will output log itself.
