### PR TITLE
Add support for compiling with GCC

### DIFF
--- a/dokan/directory.c
+++ b/dokan/directory.c
@@ -23,8 +23,10 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 #include "fileinfo.h"
 #include "list.h"
 
+#ifdef _MSC_VER
 #if _MSC_VER < 1300 // VC6
 typedef ULONG ULONG_PTR;
+#endif
 #endif
 
 /**

--- a/dokan/dokan.c
+++ b/dokan/dokan.c
@@ -26,8 +26,8 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 #include <conio.h>
 #include <process.h>
 #include <stdlib.h>
-#include <strsafe.h>
 #include <tchar.h>
+#include <strsafe.h>
 
 #define DokanMapKernelBit(dest, src, userBit, kernelBit)                       \
   if (((src) & (kernelBit)) == (kernelBit))                                    \

--- a/dokan/dokan.rc
+++ b/dokan/dokan.rc
@@ -5,7 +5,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "winres.h"
+#include "winresrc.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/dokan/dokanc.h
+++ b/dokan/dokanc.h
@@ -52,10 +52,10 @@ extern BOOL g_DebugMode;
 // DokanOptions->UseStdErr is ON?
 extern BOOL g_UseStdErr;
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || (defined(__GNUC__) && !defined(__CYGWIN__))
 
 static VOID DokanDbgPrint(LPCSTR format, ...) {
-  const char *outputString = format;    // fallback
+  const char *outputString = format; // fallback
   char *buffer = NULL;
   int length;
   va_list argp;
@@ -80,7 +80,7 @@ static VOID DokanDbgPrint(LPCSTR format, ...) {
 }
 
 static VOID DokanDbgPrintW(LPCWSTR format, ...) {
-  const WCHAR *outputString = format;   // fallback
+  const WCHAR *outputString = format; // fallback
   WCHAR *buffer = NULL;
   int length;
   va_list argp;
@@ -102,6 +102,8 @@ static VOID DokanDbgPrintW(LPCWSTR format, ...) {
   va_end(argp);
 }
 
+#if defined(_MSC_VER)
+
 #define DbgPrint(format, ...)                                                  \
   do {                                                                         \
     if (g_DebugMode) {                                                         \
@@ -120,7 +122,27 @@ static VOID DokanDbgPrintW(LPCWSTR format, ...) {
   __pragma(warning(push)) __pragma(warning(disable : 4127)) while (0)          \
       __pragma(warning(pop))
 
-#endif // MSVC
+#endif // defined(_MSC_VER)
+
+#if defined(__GNUC__)
+
+#define DbgPrint(format, ...)                                                  \
+  do {                                                                         \
+    if (g_DebugMode) {                                                         \
+      DokanDbgPrint(format, ##__VA_ARGS__);                                    \
+    }                                                                          \
+  } while (0)
+
+#define DbgPrintW(format, ...)                                                 \
+  do {                                                                         \
+    if (g_DebugMode) {                                                         \
+      DokanDbgPrintW(format, ##__VA_ARGS__);                                   \
+    }                                                                          \
+  } while (0)
+
+#endif // defined(__GNUC__)
+
+#endif // defined(_MSC_VER) || (defined(__GNUC__) && !defined(__CYGWIN__))
 
 #define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
 

--- a/dokan/mount.c
+++ b/dokan/mount.c
@@ -20,8 +20,8 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "dokani.h"
-#include <Dbt.h>
-#include <ShlObj.h>
+#include <dbt.h>
+#include <shlobj.h>
 #include <stdio.h>
 
 #pragma warning(push)

--- a/dokan/timeout.c
+++ b/dokan/timeout.c
@@ -64,7 +64,8 @@ BOOL DOKANAPI DokanResetTimeout(ULONG Timeout, PDOKAN_FILE_INFO FileInfo) {
 }
 
 /* Legacy KeepAlive - Remove for 2.0.0 */
-UINT WINAPI DokanKeepAlive(PDOKAN_INSTANCE DokanInstance) {
+UINT WINAPI DokanKeepAlive(PVOID instance) {
+  PDOKAN_INSTANCE DokanInstance = (PDOKAN_INSTANCE)instance;
   HANDLE device;
   ULONG ReturnedLength;
   WCHAR rawDeviceName[MAX_PATH];


### PR DESCRIPTION
### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (does not apply)
- [ ] I have made corresponding changes to the existing documentation (does not apply)
- [x] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

This PR adds support for cross-compiling the `dokan` subproject with GCC and mingw32-w64.
Building with mingw32-w64 eliminates the dependency to the Visual Studio C++ Runtime and allows building on a Linux build server (all our projects - even those targetting Windows - are built on Linux).
