### PR TITLE
fix read file exception

### DIFF
--- a/dokan_fuse/src/fusemain.cpp
+++ b/dokan_fuse/src/fusemain.cpp
@@ -605,14 +605,14 @@ int impl_fuse_context::read_file(LPCWSTR /*file_name*/, LPVOID buffer,
   CHECKED(cast_from_longlong(offset, &off));
   fuse_file_info finfo(hndl->make_finfo());
 
-  std::string strName = hndl->get_name();
+  std::string file_name = hndl->get_name();
   DWORD total_read = 0;
   while (total_read < num_bytes_to_read) {
     DWORD to_read = num_bytes_to_read - total_read;
     if (to_read > MAX_READ_SIZE)
       to_read = MAX_READ_SIZE;
 
-    int res = ops_.read(strName.c_str(), static_cast<char *>(buffer), to_read,
+    int res = ops_.read(file_name.c_str(), static_cast<char *>(buffer), to_read,
                         off,
                         &finfo);
     if (res < 0)

--- a/dokan_fuse/src/fusemain.cpp
+++ b/dokan_fuse/src/fusemain.cpp
@@ -605,13 +605,15 @@ int impl_fuse_context::read_file(LPCWSTR /*file_name*/, LPVOID buffer,
   CHECKED(cast_from_longlong(offset, &off));
   fuse_file_info finfo(hndl->make_finfo());
 
+  std::string strName = hndl->get_name();
   DWORD total_read = 0;
   while (total_read < num_bytes_to_read) {
     DWORD to_read = num_bytes_to_read - total_read;
     if (to_read > MAX_READ_SIZE)
       to_read = MAX_READ_SIZE;
 
-    int res = ops_.read(hndl->get_name().c_str(), static_cast<char *>(buffer), to_read, off,
+    int res = ops_.read(strName.c_str(), static_cast<char *>(buffer), to_read,
+                        off,
                         &finfo);
     if (res < 0)
       return res; // Error


### PR DESCRIPTION
Fixes # .
When reading data with a large delay, the IRP times out, which will cause the file object to be accidentally released.
When reading data in multiple reads, due to the dependency on the file object (hndl-> get_name ()), uncontrollable pointer errors will result.
This question has also been asked before: https://github.com/dokan-dev/dokany/issues/734

I fixed this problem, and through actual testing, I found that there would be no more file reading problems, but I do n’t know if the data returned by read can still be received by the kernel and processed correctly when the file object is released. At least my application looks normal.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-Compare the code, only two lines of code changed
-
-
