### PR TITLE
feat: use stbuf in dokan_fuse readdir callback

### DIFF
--- a/dokan_fuse/src/fusemain.cpp
+++ b/dokan_fuse/src/fusemain.cpp
@@ -297,6 +297,9 @@ int impl_fuse_context::walk_directory(void *buf, const char *name,
   if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0) {// Special entries
     stat.st_mode |= S_IFDIR; // TODO: fill directory params here!!!
   }
+  else if (stbuf != nullptr) {
+    memcpy(&stat, stbuf, sizeof(FUSE_STAT));
+  }
   else if (ctx->ops_.getattr) {
     CHECKED(ctx->ops_.getattr((dirname + name).c_str(), &stat));
   }


### PR DESCRIPTION
Fixes # .

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- use stbuf params in readdir callback, which can improve performance
