### PR TITLE
Allow disconnecting of network drives

### DIFF
--- a/dokan/dokan.c
+++ b/dokan/dokan.c
@@ -762,6 +762,9 @@ BOOL DokanStart(PDOKAN_INSTANCE Instance) {
   if (Instance->DokanOptions->Options & DOKAN_OPTION_DISABLE_OPLOCKS) {
     eventStart.Flags |= DOKAN_EVENT_DISABLE_OPLOCKS;
   }
+  if (Instance->DokanOptions->Options & DOKAN_OPTION_ENABLE_UNMOUNT_NETWORK_DRIVE) {
+    eventStart.Flags |= DOKAN_EVENT_ENABLE_NETWORK_UNMOUNT;
+  }
   if (Instance->DokanOptions->Options &
       DOKAN_OPTION_ENABLE_FCB_GARBAGE_COLLECTION) {
     eventStart.Flags |= DOKAN_EVENT_ENABLE_FCB_GC;

--- a/dokan/dokan.h
+++ b/dokan/dokan.h
@@ -124,6 +124,8 @@ extern "C" {
  * but for case insensitive they are the same.
  */
 #define DOKAN_OPTION_CASE_SENSITIVE 4096
+/** Allows unmounting of network drive via explorer */
+#define DOKAN_OPTION_ENABLE_UNMOUNT_NETWORK_DRIVE 8192
 
 /** @} */
 

--- a/dokan_np/dokannp.c
+++ b/dokan_np/dokannp.c
@@ -225,7 +225,35 @@ DWORD APIENTRY NPAddConnection3(__in HWND WndOwner,
 
 DWORD APIENTRY NPCancelConnection(__in LPWSTR Name, __in BOOL Force) {
   DbgPrintW(L"NpCancelConnection %s %d\n", Name, Force);
-  return WN_SUCCESS;
+
+  ULONG nbRead = 0;
+  WCHAR dosDevice[] = L"\\DosDevices\\C:";
+  PDOKAN_CONTROL dokanControl = DokanGetMountPointList(FALSE, &nbRead);
+  if (dokanControl == NULL) {
+    DbgPrintW(L"NpGetConnection DokanGetMountPointList failed\n");
+    return WN_NOT_CONNECTED;
+  }
+
+  dosDevice[12] = Name[0];
+
+  for (unsigned int i = 0; i < nbRead; ++i) {
+    if (wcscmp(dokanControl[i].MountPoint, dosDevice) == 0) {
+      if (dokanControl[i].MountOptions & DOKAN_EVENT_ENABLE_NETWORK_UNMOUNT) {
+        DokanReleaseMountPointList(dokanControl);
+        if (DokanRemoveMountPoint(Name)) {
+          DbgPrintW(L"NpCancelConnection: DokanRemoveMountPoint succeeded\n");
+          return WN_SUCCESS;
+        } else {
+          DbgPrintW(L"NpCancelConnection: DokanRemoveMountPoint failed\n");
+          return WN_BAD_VALUE;
+        }
+      }
+    }
+  }
+
+  DbgPrintW(L"NpCancelConnection Disconnect was ignored\n");
+
+  return WN_NO_ERROR;
 }
 
 DWORD APIENTRY NPGetConnection(__in LPWSTR LocalName, __out LPWSTR RemoteName,

--- a/samples/dokan_memfs/main.cpp
+++ b/samples/dokan_memfs/main.cpp
@@ -40,6 +40,7 @@ void show_usage() {
                 "  /t ThreadCount (ex. /t 5)\t\t\t Number of threads to be used internally by Dokan library.\n\t\t\t\t\t\t More threads will handle more event at the same time.\n"
                 "  /d (enable debug output)\t\t\t Enable debug output to an attached debugger.\n"
                 "  /i (Timeout in Milliseconds ex. /i 30000)\t Timeout until a running operation is aborted and the device is unmounted.\n"
+                "  /x (network unmount)\t\t\t Allows unmounting network drive from file explorer\n"
                 "Examples:\n"
                 "\tmemfs.exe \t\t\t# Mount as a local filesystem into a drive of letter M:\\.\n"
                 "\tmemfs.exe /l P:\t\t\t# Mount as a local filesystem into a drive of letter P:\\.\n"
@@ -66,6 +67,8 @@ int __cdecl wmain(ULONG argc, PWCHAR argv[]) {
         dokan_memfs->current_session = true;
       } else if (arg == L"/d") {
         dokan_memfs->debug_log = true;
+      } else if (arg == L"/x") {
+        dokan_memfs->enable_network_unmount = true;
       } else {
         if (i + 1 >= argc) {
           show_usage();

--- a/samples/dokan_memfs/memfs.cpp
+++ b/samples/dokan_memfs/memfs.cpp
@@ -49,6 +49,9 @@ void memfs::run() {
     if (unc_name[0]) {
       dokan_options.UNCName = unc_name;
     }
+    if (enable_network_unmount) {
+      dokan_options.Options |= DOKAN_OPTION_ENABLE_UNMOUNT_NETWORK_DRIVE;
+    }
   } else if (removable_drive) {
     dokan_options.Options |= DOKAN_OPTION_REMOVABLE;
   } else {

--- a/samples/dokan_memfs/memfs.h
+++ b/samples/dokan_memfs/memfs.h
@@ -54,6 +54,7 @@ class memfs {
   bool removable_drive = false;
   bool current_session = false;
   bool debug_log = false;
+  bool enable_network_unmount = false;
   ULONG timeout = 0;
 
   // FileSystem context runtime

--- a/samples/dokan_mirror/mirror.c
+++ b/samples/dokan_mirror/mirror.c
@@ -1549,7 +1549,8 @@ void ShowUsage() {
           "  /f User mode Lock\t\t\t\t Enable Lockfile/Unlockfile operations. Otherwise Dokan will take care of it.\n"
           "  /e Disable OpLocks\t\t\t\t Disable OpLocks kernel operations. Otherwise Dokan will take care of it.\n"
           "  /i (Timeout in Milliseconds ex. /i 30000)\t Timeout until a running operation is aborted and the device is unmounted.\n"
-          "  /z Enabled FCB GC. Might speed up on env with filter drivers (Anti-virus) slowing down the system.\n\n"
+          "  /z Enabled FCB GC. Might speed up on env with filter drivers (Anti-virus) slowing down the system.\n"
+          "  /x (network unmount)\t\t\t Allows unmounting network drive from file explorer\n\n"
           "Examples:\n"
           "\tmirror.exe /r C:\\Users /l M:\t\t\t# Mirror C:\\Users as RootDirectory into a drive of letter M:\\.\n"
           "\tmirror.exe /r C:\\Users /l C:\\mount\\dokan\t# Mirror C:\\Users as RootDirectory into NTFS folder C:\\mount\\dokan.\n"
@@ -1636,6 +1637,9 @@ int __cdecl wmain(ULONG argc, PWCHAR argv[]) {
       break;
     case L'z':
       dokanOptions.Options |= DOKAN_OPTION_ENABLE_FCB_GARBAGE_COLLECTION;
+      break;
+    case L'x':
+      dokanOptions.Options |= DOKAN_OPTION_ENABLE_UNMOUNT_NETWORK_DRIVE;
       break;
     case L'b':
       // Only work when mirroring a folder with setCaseSensitiveInfo option enabled on win10

--- a/sys/create.c
+++ b/sys/create.c
@@ -588,7 +588,7 @@ Return Value:
       __leave;
     }
 
-    caseInSensitive = !dcb->CaseSensitive;
+    caseInSensitive = !(dcb->MountOptions & DOKAN_EVENT_CASE_SENSITIVE);
 
     // this memory is freed by DokanGetFCB if needed
     // "+ sizeof(WCHAR)" is for the last NULL character

--- a/sys/dokan.c
+++ b/sys/dokan.c
@@ -448,7 +448,7 @@ NTSTATUS DokanCheckOplock(
   ASSERT(Fcb->Vcb != NULL);
   ASSERT(Fcb->Vcb->Dcb != NULL);
   if (Fcb->Vcb != NULL && Fcb->Vcb->Dcb != NULL &&
-      !Fcb->Vcb->Dcb->OplocksDisabled) {
+      !(Fcb->Vcb->Dcb->MountOptions & DOKAN_EVENT_DISABLE_OPLOCKS)) {
     return FsRtlCheckOplock(DokanGetFcbOplock(Fcb), Irp, Context,
                             CompletionRoutine, PostIrpRoutine);
   }

--- a/sys/dokan.h
+++ b/sys/dokan.h
@@ -264,7 +264,6 @@ typedef struct _DokanDiskControlBlock {
   USHORT UseAltStream;
   USHORT UseMountManager;
   USHORT MountGlobally;
-  USHORT FileLockInUserMode;
 
   // to make a unique id for pending IRP
   ULONG SerialNumber;
@@ -284,9 +283,6 @@ typedef struct _DokanDiskControlBlock {
   // point yet.
   BOOLEAN MountPointDetermined;
 
-  // Whether any oplock functionality should be disabled.
-  BOOLEAN OplocksDisabled;
-
   // How often to garbage-collect FCBs. If this is 0, we use the historical
   // default behavior of freeing them on the spot and in the current context
   // when the FileCount reaches 0. If this is nonzero, then a background thread
@@ -297,17 +293,9 @@ typedef struct _DokanDiskControlBlock {
   // repeatedly rebuilding state that they attach to the FCB header.
   ULONG FcbGarbageCollectionIntervalMs;
 
-  // CaseSenitive FileName: NTFS can look to be case-insensitive
-  // but in some situation it can also be case-sensitive :
-  // * NTFS keep the filename casing used during Create internally.
-  // * Open "MyFile" on NTFS can open "MYFILE" if it exists.
-  // * FILE_FLAG_POSIX_SEMANTICS (IRP_MJ_CREATE: SL_CASE_SENSITIVE)
-  //   can be used during Create to make the lookup case-sensitive.
-  // * Since Win10, NTFS can have specific directories
-  //   case-sensitive / insensitive, even if the device tags says otherwise.
-  // Dokan choose to support case-sensitive or case-insensitive filesystem
-  // but not those NTFS specific scenarios.
-  BOOLEAN CaseSensitive;
+  // Contains mount options from user space. See DOKAN_EVENT_* in public.h
+  // for possible values.
+  ULONG MountOptions;
 
 } DokanDCB, *PDokanDCB;
 

--- a/sys/fscontrol.c
+++ b/sys/fscontrol.c
@@ -164,7 +164,7 @@ NTSTATUS DokanOplockRequest(__in PIRP *pIrp) {
     return STATUS_INVALID_PARAMETER;
   }
 
-  if (Dcb->OplocksDisabled) {
+  if (Dcb->MountOptions & DOKAN_EVENT_DISABLE_OPLOCKS) {
     return STATUS_NOT_SUPPORTED;
   }
 
@@ -221,7 +221,7 @@ NTSTATUS DokanOplockRequest(__in PIRP *pIrp) {
       DokanFCBLockRW(Fcb);
       AcquiredFcb = TRUE;
 
-      if (!Dcb->FileLockInUserMode) {
+      if (!(Dcb->MountOptions & DOKAN_EVENT_FILELOCK_USER_MODE)) {
 
         if (FsRtlOplockIsSharedRequest(Irp)) {
           //
@@ -942,6 +942,7 @@ NTSTATUS DokanMountVolume(__in PDEVICE_OBJECT DiskDevice, __in PIRP Irp) {
   mountEntry = FindMountEntry(dcb->Global, &dokanControl, TRUE);
   if (mountEntry != NULL) {
     mountEntry->MountControl.VolumeDeviceObject = volDeviceObject;
+    mountEntry->MountControl.MountOptions = dcb->MountOptions;
   } else {
     ExReleaseResourceLite(&dcb->Resource);
     return DokanLogError(&logger, STATUS_DEVICE_REMOVED,

--- a/sys/lock.c
+++ b/sys/lock.c
@@ -173,7 +173,7 @@ DokanDispatchLock(__in PDEVICE_OBJECT DeviceObject, __in PIRP Irp) {
     DokanFCBLockRW(fcb);
 
     OplockDebugRecordMajorFunction(fcb, IRP_MJ_LOCK_CONTROL);
-    if (dcb->FileLockInUserMode) {
+    if (dcb->MountOptions & DOKAN_EVENT_FILELOCK_USER_MODE) {
 
       eventLength = sizeof(EVENT_CONTEXT) + fcb->FileName.Length;
       eventContext = AllocateEventContext(vcb->Dcb, Irp, eventLength, ccb);

--- a/sys/public.h
+++ b/sys/public.h
@@ -400,9 +400,22 @@ typedef struct _EVENT_INFORMATION {
 #define DOKAN_EVENT_MOUNT_MANAGER                                   (1 << 3)
 #define DOKAN_EVENT_CURRENT_SESSION                                 (1 << 4)
 #define DOKAN_EVENT_FILELOCK_USER_MODE                              (1 << 5)
+// Whether any oplock functionality should be disabled.
 #define DOKAN_EVENT_DISABLE_OPLOCKS                                 (1 << 6)
 #define DOKAN_EVENT_ENABLE_FCB_GC                                   (1 << 7)
+// CaseSenitive FileName: NTFS can look to be case-insensitive
+// but in some situation it can also be case-sensitive :
+// * NTFS keep the filename casing used during Create internally.
+// * Open "MyFile" on NTFS can open "MYFILE" if it exists.
+// * FILE_FLAG_POSIX_SEMANTICS (IRP_MJ_CREATE: SL_CASE_SENSITIVE)
+//   can be used during Create to make the lookup case-sensitive.
+// * Since Win10, NTFS can have specific directories
+//   case-sensitive / insensitive, even if the device tags says otherwise.
+// Dokan choose to support case-sensitive or case-insensitive filesystem
+// but not those NTFS specific scenarios.
 #define DOKAN_EVENT_CASE_SENSITIVE                                  (1 << 8)
+// Enables unmounting of network drives via file explorer
+#define DOKAN_EVENT_ENABLE_NETWORK_UNMOUNT                           (1 << 9)
 
 typedef struct _EVENT_DRIVER_INFO {
   ULONG DriverVersion;
@@ -472,6 +485,8 @@ typedef struct _DOKAN_CONTROL {
 #endif
   /** Session ID of calling process */
   ULONG SessionId;
+  /** Contains information about the flags on the mount */
+  ULONG MountOptions;
 } DOKAN_CONTROL, *PDOKAN_CONTROL;
 
 #endif // PUBLIC_H_


### PR DESCRIPTION
Fixes https://github.com/dokan-dev/dokan-dotnet/issues/250

I could not figure out how to pass down the setting, but this should nonetheless be a good new default behavior in my opinion.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add the option to enable disconnecting / unmounting a network drive from explorer directly
