### PR TITLE
docs: fix simple typo, specifed -> specified

### DIFF
--- a/dokan/create.c
+++ b/dokan/create.c
@@ -161,7 +161,7 @@ VOID DispatchCreate(HANDLE Handle, // This handle is not for a file. It is for
   origOptions = options;
 
   // to open directory
-  // even if this flag is not specifed,
+  // even if this flag is not specified,
   // there is a case to open a directory
   if (options & FILE_DIRECTORY_FILE) {
     // DbgPrint("FILE_DIRECTORY_FILE\n");

--- a/dokan/directory.c
+++ b/dokan/directory.c
@@ -405,8 +405,8 @@ VOID ClearFindData(PLIST_ENTRY ListHead) {
   }
 }
 
-// add entry which matches the pattern specifed in EventContext
-// to the buffer specifed in EventInfo
+// add entry which matches the pattern specified in EventContext
+// to the buffer specified in EventInfo
 //
 LONG MatchFiles(PEVENT_CONTEXT EventContext, PEVENT_INFORMATION EventInfo,
                 PLIST_ENTRY FindDataList, BOOLEAN PatternCheck,

--- a/sys/create.c
+++ b/sys/create.c
@@ -613,7 +613,7 @@ Return Value:
                         (needBackSlashAfterRelatedFile ? sizeof(WCHAR) : 0),
                     fileObject->FileName.Buffer, fileObject->FileName.Length);
     } else {
-      // if related file object is not specifed, copy the file name of file
+      // if related file object is not specified, copy the file name of file
       // object
       RtlCopyMemory(fileName, fileObject->FileName.Buffer,
                     fileObject->FileName.Length);

--- a/sys/fileinfo.c
+++ b/sys/fileinfo.c
@@ -277,7 +277,7 @@ VOID DokanCompleteQueryInformation(__in PIRP_ENTRY IrpEntry,
   // available buffer size
   bufferLen = irpSp->Parameters.QueryFile.Length;
 
-  // buffer is not specifed or short of size
+  // buffer is not specified or short of size
   if (bufferLen == 0 || buffer == NULL || bufferLen < EventInfo->BufferLength) {
     info = 0;
     status = STATUS_INSUFFICIENT_RESOURCES;


### PR DESCRIPTION
There is a small typo in dokan/create.c, dokan/directory.c, sys/create.c, sys/fileinfo.c.

Should read `specified` rather than `specifed`.

