### PR TITLE
remove BSF_NOTIMEOUTIFNOTHUNG flag in BroadcastSystemMessage

### DIFF
--- a/dokan/mount.c
+++ b/dokan/mount.c
@@ -532,7 +532,7 @@ void DokanBroadcastLink(WCHAR cLetter, BOOL bRemoved, BOOL safe) {
   params.dbcv_flags = 0;
 
   if (BroadcastSystemMessage(
-          BSF_NOHANG | BSF_FORCEIFHUNG | BSF_NOTIMEOUTIFNOTHUNG, &receipients,
+          BSF_NOHANG | BSF_FORCEIFHUNG, &receipients,
           WM_DEVICECHANGE, device_event, (LPARAM)&params) <= 0) {
 
     DbgPrint("DokanBroadcastLink: BroadcastSystemMessage failed - %d\n",


### PR DESCRIPTION
Fixes #957.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [ ] I have cleaned up the commit history (use rebase and squash)

I think it isn't a significant enough change for updating the change log or even a comment.

I think a rebase/squash isn't needed.  I did only one commit.

### Changes proposed in this pull request:

Using BSF_NOTIMEOUTIFNOTHUNG in the BroadcastSystemMessage that is done in DokanBroadcastLink after mounting to a drive letter could cause the BroadcastSystemMessage call to block long enough to cause the driver to timeout the fs.  This flag is not necessary so it was removed.
-
-
-
