### PR TITLE
Reduce desired access rights for loop device handle and keepalive handle

### DIFF
--- a/dokan/dokan.c
+++ b/dokan/dokan.c
@@ -280,7 +280,7 @@ int DOKANAPI DokanMain(PDOKAN_OPTIONS DokanOptions,
   StringCbPrintfW(keepalive_path, sizeof(keepalive_path), L"\\\\?%s%s",
                   instance->DeviceName, DOKAN_KEEPALIVE_FILE_NAME);
   HANDLE keepalive_handle =
-      CreateFile(keepalive_path, GENERIC_READ, 0, NULL, OPEN_EXISTING, 0, NULL);
+      CreateFile(keepalive_path, 0, 0, NULL, OPEN_EXISTING, 0, NULL);
   if (keepalive_handle == INVALID_HANDLE_VALUE) {
     // We don't consider this a fatal error because the keepalive handle is only
     // needed for abnormal termination cases anyway.
@@ -407,7 +407,7 @@ UINT WINAPI DokanLoop(PVOID pDokanInstance) {
   while (status) {
 
     device = CreateFile(rawDeviceName,                 // lpFileName
-                   GENERIC_READ | GENERIC_WRITE,       // dwDesiredAccess
+                   GENERIC_READ,       // dwDesiredAccess
                    FILE_SHARE_READ | FILE_SHARE_WRITE, // dwShareMode
                    NULL,                               // lpSecurityAttributes
                    OPEN_EXISTING,                      // dwCreationDistribution


### PR DESCRIPTION
Mitigates #953.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

This PR reduces the problem that a recently mounted device is directly unmounted if certain AV software is installed in the OS.
This is done by implementing the comments made in #953 (basically a reduction of the desirered access rights for certain CreateFile calls). Since there is still an open discussion for a bigger change in the issue, this PR is not intended to close it, but to provide a short term fix.
