### PR TITLE
SYS - Check the return code when deleting the file view

### DIFF
--- a/sys/cleanup.c
+++ b/sys/cleanup.c
@@ -210,7 +210,7 @@ VOID DokanCompleteCleanup(__in PIRP_ENTRY IrpEntry,
                             FILE_ACTION_MODIFIED);
   }
 
-  if (DokanFCBFlagsIsSet(fcb, DOKAN_DELETE_ON_CLOSE)) {
+  if (DokanFCBFlagsIsSet(fcb, DOKAN_DELETE_ON_CLOSE) && status == STATUS_SUCCESS) {
     if (DokanFCBFlagsIsSet(fcb, DOKAN_FILE_DIRECTORY)) {
       DokanNotifyReportChange(fcb, FILE_NOTIFY_CHANGE_DIR_NAME,
                               FILE_ACTION_REMOVED);
@@ -226,7 +226,7 @@ VOID DokanCompleteCleanup(__in PIRP_ENTRY IrpEntry,
   (VOID) FsRtlFastUnlockAll(&fcb->FileLock, fileObject,
                             IoGetRequestorProcess(irp), NULL);
 
-  if (DokanFCBFlagsIsSet(fcb, DOKAN_FILE_DIRECTORY)) {
+  if (DokanFCBFlagsIsSet(fcb, DOKAN_FILE_DIRECTORY) && status == STATUS_SUCCESS) {
     FsRtlNotifyCleanup(vcb->NotifySync, &vcb->DirNotifyList, ccb);
   }
 


### PR DESCRIPTION
When the deletion of the underlying user-mode file system fails, the file view will still be deleted. File still exists after refreshing.

Fixes # 969

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- When user delete the file failed, it will not remove the file view in the window.
