### PR TITLE
FUSE - Fix compare size_t to zero in fuse utils

### DIFF
--- a/dokan_fuse/include/utils.h
+++ b/dokan_fuse/include/utils.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 void utf8_to_wchar_buf_old(const char *src, wchar_t *res, int maxlen);
-size_t utf8_to_wchar_buf(const char *src, wchar_t *res, int maxlen);
+int utf8_to_wchar_buf(const char *src, wchar_t *res, int maxlen);
 
 FILETIME unixTimeToFiletime(time_t t);
 time_t filetimeToUnixTime(const FILETIME *ft);

--- a/dokan_fuse/src/dokanfuse.cpp
+++ b/dokan_fuse/src/dokanfuse.cpp
@@ -519,7 +519,7 @@ int do_fuse_loop(struct fuse *fs, bool mt) {
   }
 
   wchar_t mount[MAX_PATH + 1];
-  if (utf8_to_wchar_buf(fs->ch->mountpoint.c_str(), mount, MAX_PATH) == static_cast<size_t>(-1)) {
+  if (utf8_to_wchar_buf(fs->ch->mountpoint.c_str(), mount, MAX_PATH) == -1) {
     free(dokanOptions);
     return -1;
   }
@@ -686,7 +686,7 @@ void fuse_unmount(const char *mountpoint, struct fuse_chan *ch) {
   // Unmount attached FUSE filesystem
   if (ch->ResolvedDokanRemoveMountPoint) {
     wchar_t wmountpoint[MAX_PATH + 1];
-    if (utf8_to_wchar_buf(mountpoint, wmountpoint, MAX_PATH) == static_cast<size_t>(-1)) {
+    if (utf8_to_wchar_buf(mountpoint, wmountpoint, MAX_PATH) == -1) {
       return;
     }
     wchar_t &last = wmountpoint[wcslen(wmountpoint) - 1];


### PR DESCRIPTION
We've got an infinite loop problem in 'convert_char' function when the get_func fail, because the return value in size_t would never less than zero.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Fix the infinite loop problem by changing several function's return type from size_t to int.
- 

