### PR TITLE
Revert "CI: Install MSYS2 on VS2019 image"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,7 @@
       DOKAN_CI_CACHE: C:\dokan_ci_cache
       DOXYGEN_INST_DIR: '%DOKAN_CI_CACHE%\doxygen'
       CYG_CACHE: '%DOKAN_CI_CACHE%\cygwin'
-      MSYS2_CACHE: '%TEMP%\msys2-cache'
-      MSYS2_INST_DIR: '%DOKAN_CI_CACHE%\msys64'
+      MSYS2_CACHE: '%DOKAN_CI_CACHE%\msys2-cache'
 #     CHOCO_CACHE: '%DOKAN_CI_CACHE%\choco'
       WLK_INST_CACHE: '%DOKAN_CI_CACHE%\wlk_inst'
       DOKAN_MAIN_BUILD_JOB_NAME: "Image: Visual Studio 2019; Configuration: All"
@@ -136,36 +135,16 @@
         if ($env:CONFIGURATION -eq "All") {
           function bash($bash_command) {
             Write-Host "MSYS2-Bash: $bash_command"
-            Exec-External {& $env:MSYS2_INST_DIR\usr\bin\bash.exe --login -c $bash_command }
+            Exec-External {& C:\msys64\usr\bin\bash.exe --login -c $bash_command }
             Write-Host "MSYS2-Bash $bash_command " -NoNewLine
             Write-Host "[ OK ]" -ForegroundColor Green
           }
-
-          function install-msys2() {
-            if (Test-Path $env:MSYS2_INST_DIR) {
-              Write-Host "MSYS2 already installed at $env:MSYS2_INST_DIR"
-              return
-            }
-            $msys2_tar_url = "https://github.com/msys2/msys2-installer/releases/download/2020-07-20/msys2-base-x86_64-20200720.tar.xz"
-            $msys2_tar_sha256 = "24f0a7a3f499d9309bb55bcde5d34a08e752922c3bee9de3a33d2c40896a1496"
-            $msys2_tar = "$env:TEMP\msys2-base-x86_64.tar.xz"
-            Invoke-WebRequest $msys2_tar_url -OutFile $msys2_tar
-            if ($(Get-FileHash -Algorithm SHA256 $msys2_tar).Hash -ne $msys2_tar_sha256) {
-              throw "Hash mismatch while downloading msys2"
-            }
-            Write-Host "Extracting MSYS2"
-            Exec-External {& cmd /c "7z x -so $msys2_tar | 7z x -si -ttar -o$env:MSYS2_INST_DIR\..\"}
-            # Needed to execute scripts on first start. Also acts as a sanity check.
-            bash "echo MSYS2 installed"
-          }
-          install-msys2
-          
           New-Item -Force -Type Directory $env:MSYS2_CACHE
-          $unix_msys2_cache = (Exec-External {& $env:MSYS2_INST_DIR\usr\bin\bash.exe --login -c "cygpath '${env:MSYS2_CACHE}'"})
-          
+          $unix_msys2_cache = (Exec-External {& C:\msys64\usr\bin\bash.exe --login -c "cygpath '${env:MSYS2_CACHE}'"})
+
           # Update keyring to fix possible package signatures we faced in the past.
           bash "pacman -Sy --noconfirm --cache `"$unix_msys2_cache`" msys2-keyring"
-          
+
           # We run the upgrade three times, because MSYS2 cannot upgrade itself without restarting
           # TODO: detect if restart is necessary and only run as many times as needed.
           #       Maybe two times is enough in all cases, but better be safe than sorry and run it three times.
@@ -179,7 +158,7 @@
           #
           # is displayed when trying to update followed by an exit rather
           # than selecting yes.
-          
+
           for ($i = 0; $i -lt 3; $i++) {
             bash "pacman -Syuu --ask 20 --noconfirm --cache `"$unix_msys2_cache`""
           }


### PR DESCRIPTION
This reverts commit f980bb2bfb504dcea7538af2587c23492ce63ef2.
MSYS2 is by now installed in the "Visual Studio 2019" image on AppVeyor.
Thus, we can simply update the existing installing like it was done
previously.

As a side effect, this also avoids exceeding AppVeyor's maximum cache
size, because substantially less data needs to be cached.

Fixes https://ci.appveyor.com/project/Maxhy/dokany/build/job/a1q24gl0irqga8ao#L3581 
```
Updating build cache...
Cache 'C:\dokan_ci_cache' - Zipping...Unable to save cache - skipping
Compressed cache item cannot exceed 1,048,576,000 bytes.
Build success
```

### Checklist

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the existing documentation
- [ x ] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [ x ] I have cleaned up the commit history (use rebase and squash)