### PR TITLE
FUSE - update library name in module definition

### DIFF
--- a/dokan_fuse/src/dokanfuse.def
+++ b/dokan_fuse/src/dokanfuse.def
@@ -1,4 +1,4 @@
-LIBRARY	dokanfuse1
+LIBRARY	dokanfuse2
 
 EXPORTS
 


### PR DESCRIPTION


### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

When dynamic linking the dokanfuse library, the application would still looking for the dll named dokanfuse1.
Need update it in file dokanfuse.def.
