### PR TITLE
Library - Remove unused DOKAN_LINK_INFORMATION

### DIFF
--- a/sys/public.h
+++ b/sys/public.h
@@ -493,12 +493,6 @@ typedef struct _DOKAN_RENAME_INFORMATION {
 #pragma warning(pop)
 #endif
 
-typedef struct _DOKAN_LINK_INFORMATION {
-  BOOLEAN ReplaceIfExists;
-  ULONG FileNameLength;
-  WCHAR FileName[1];
-} DOKAN_LINK_INFORMATION, *PDOKAN_LINK_INFORMATION;
-
 /**
 * \struct DOKAN_MOUNT_POINT_INFO
 * \brief Dokan Mount point information


### PR DESCRIPTION
### Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the existing documentation
- [X] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [X] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- `DOKAN_LINK_INFORMATION` is not used anymore.
