### PR TITLE
Library - Allow FindFilesWithPattern to return STATUS_NOT_IMPLEMENTED

### DIFF
--- a/dokan/dokan.h
+++ b/dokan/dokan.h
@@ -400,8 +400,8 @@ typedef struct _DOKAN_OPERATIONS {
   * \brief FindFiles Dokan API callback
   *
   * List all files in the requested path.
-  * If this function is not implemented by not assigning the function pointer,
-  * \ref DOKAN_OPERATIONS.FindFilesWithPattern will instead be called with a wildcard as pattern.
+  * \ref DOKAN_OPERATIONS.FindFilesWithPattern is checked first. If it is not implemented or
+  * returns \c STATUS_NOT_IMPLEMENTED, then FindFiles is called, if assigned.
   * It is recommended to have this implemented for performance reason.
   *
   * \param FileName File path requested by the Kernel on the FileSystem.
@@ -421,7 +421,7 @@ typedef struct _DOKAN_OPERATIONS {
   * The search pattern is a Windows MS-DOS-style expression.
   * It can contain wild cards and extended characters or none of them. See \ref DokanIsNameInExpression.
   *
-  * If the function is not implemented by not assigning the function pointer, \ref DOKAN_OPERATIONS.FindFiles
+  * If the function is not implemented, \ref DOKAN_OPERATIONS.FindFiles
   * will be called instead and the result will be filtered internally by the library.
   * It is recommended to have this implemented for performance reason.
   *


### PR DESCRIPTION
Reverts #9eb4d15bc4c533b73dd718b3114c0be758f874d9

### Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the existing documentation
- [X] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [X] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

[I'm upgrading the Rust bindings to use ^2](https://github.com/dokan-dev/dokan-rust/issues/3). The high-level API always defines `FindFilesWithPattern`, with a default implementation returning `STATUS_NOT_IMPLEMENTED`. But the MemFS example was not working well. I discovered that a few months ago, this function was not allowed to return `STATUS_NOT_IMPLEMENTED` anymore. I find that's too bad.

After I tried for a long time to allow Rust to choose whether `FindFiles` and `FindFilesWithPattern` are defined, I finally moved to changing the C library's behavior. It gives back the ability to all functions to return `STATUS_NOT_IMPLEMENTED`. I believe this will be beneficial for other bindings as well.