### PR TITLE
Library - Fix build on MinGW32

### DIFF
--- a/dokan/fileinfo.c
+++ b/dokan/fileinfo.c
@@ -26,6 +26,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 #include <ntstatus.h>
 #include <stdio.h>
 #include <assert.h>
+#include <stddef.h>
 
 #define DOKAN_STREAM_ENTRY_ALIGNMENT 8
 


### PR DESCRIPTION
### Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the existing documentation
- [X] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [X] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

Still upgrading the Rust bindings to 2.0.5...

[Compilation on MinGW32](https://ci.appveyor.com/project/Liryna/dokan-rust/builds/44926022/job/d66wdi8dnyf9tds7) produces these errors:

```
  src/dokany/dokan\fileinfo.c: In function 'DokanEndDispatchFindStreams':
  src/dokany/dokan\dokani.h:197:34: warning: implicit declaration of function 'offsetof' [-Wimplicit-function-declaration]
    197 |   ((ioEvent)->EventResultSize >= offsetof(EVENT_INFORMATION, Buffer)           \
        |                                  ^~~~~~~~
  src/dokany/dokan\dokani.h:197:34: note: in definition of macro 'IOEVENT_RESULT_BUFFER_SIZE'
    197 |   ((ioEvent)->EventResultSize >= offsetof(EVENT_INFORMATION, Buffer)           \
        |                                  ^~~~~~~~
  src/dokany/dokan\fileinfo.c:29:1: note: 'offsetof' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'?
     28 | #include <assert.h>
    +++ |+#include <stddef.h>
     29 | 
  src/dokany/dokan\dokani.h:197:43: error: expected expression before 'EVENT_INFORMATION'
    197 |   ((ioEvent)->EventResultSize >= offsetof(EVENT_INFORMATION, Buffer)           \
        |                                           ^~~~~~~~~~~~~~~~~
  src/dokany/dokan\dokani.h:197:43: note: in definition of macro 'IOEVENT_RESULT_BUFFER_SIZE'
    197 |   ((ioEvent)->EventResultSize >= offsetof(EVENT_INFORMATION, Buffer)           \
        |                                           ^~~~~~~~~~~~~~~~~
  src/dokany/dokan\dokani.h:198:48: error: expected expression before 'EVENT_INFORMATION'
    198 |        ? (ioEvent)->EventResultSize - offsetof(EVENT_INFORMATION, Buffer)      \
        |                                                ^~~~~~~~~~~~~~~~~
  src/dokany/dokan\dokani.h:198:48: note: in definition of macro 'IOEVENT_RESULT_BUFFER_SIZE'
    198 |        ? (ioEvent)->EventResultSize - offsetof(EVENT_INFORMATION, Buffer)      \
        |      
```

I just made what I was told!