### PR TITLE
align buffer at 64-byte boundary so that memcpy can take advantage of…

### DIFF
--- a/dokan/dokan.c
+++ b/dokan/dokan.c
@@ -1366,8 +1366,8 @@ VOID DOKANAPI DokanMapKernelToUserCreateFileFlags(
 }
 
 VOID DOKANAPI DokanInit() {
-  // ensure 64-bit alignment
-  assert(FIELD_OFFSET(EVENT_INFORMATION, Buffer) % 8 == 0);
+  // ensure 64-byte alignment, memcpy runs much faster on 64-byte aligned buffer on moden CPU
+  static_assert(FIELD_OFFSET(EVENT_INFORMATION, Buffer) % 64 == 0, "alignment error");
 
   // this is not as safe as a critical section so to some degree we rely on
   // the user to do the right thing

--- a/sys/public.h
+++ b/sys/public.h
@@ -388,6 +388,7 @@ typedef struct _EVENT_INFORMATION {
   ULONG64 Context;
   ULONG BufferLength;
   ULONG PullEventTimeoutMs;
+  UCHAR Padding[24]; // ensure buffer is 64-byte aligned
   UCHAR Buffer[DOKAN_EVENT_INFO_MIN_BUFFER_SIZE];
 } EVENT_INFORMATION, *PEVENT_INFORMATION;
 


### PR DESCRIPTION
memcpy can take advantage of erms or avx instructions on moden cpus
these instructions run much faster (up to 20% in my test case) on 64-byte aligned address