### PR TITLE
Register callback for dismount

### DIFF
--- a/dokan/dokan.c
+++ b/dokan/dokan.c
@@ -620,6 +620,25 @@ DWORD DOKANAPI DokanWaitForFileSystemClosed(_In_ DOKAN_HANDLE DokanInstance,
   return WaitForSingleObject(instance->DeviceClosedWaitHandle, dwMilliseconds);
 }
 
+BOOL DOKANAPI DokanRegisterWaitForFileSystemClosed(
+    _In_ DOKAN_HANDLE DokanInstance, _Out_ PHANDLE WaitHandle,
+    _In_ WAITORTIMERCALLBACKFUNC Callback, _In_ PVOID Context,
+    ULONG dwMilliseconds) {
+  DOKAN_INSTANCE *instance = (DOKAN_INSTANCE *)DokanInstance;
+  if (!instance) {
+    return FALSE;
+  }
+  return RegisterWaitForSingleObject(
+      WaitHandle, instance->DeviceClosedWaitHandle, Callback, Context,
+      dwMilliseconds, WT_EXECUTEONLYONCE);
+}
+
+BOOL DOKANAPI DokanUnregisterWaitForFileSystemClosed(
+    _In_ HANDLE WaitHandle, BOOL WaitForCallbacks) {
+  return UnregisterWaitEx(
+      WaitHandle, WaitForCallbacks ? INVALID_HANDLE_VALUE : NULL);
+}
+
 VOID DOKANAPI DokanCloseHandle(_In_ DOKAN_HANDLE DokanInstance) {
   DOKAN_INSTANCE *instance = (DOKAN_INSTANCE *)DokanInstance;
   if (!instance) {

--- a/dokan/dokan.def
+++ b/dokan/dokan.def
@@ -32,4 +32,6 @@ DokanShutdown
 DokanCreateFileSystem
 DokanIsFileSystemRunning
 DokanWaitForFileSystemClosed
+DokanRegisterWaitForFileSystemClosed
+DokanUnregisterWaitForFileSystemClosed
 DokanCloseHandle

--- a/dokan/dokan.h
+++ b/dokan/dokan.h
@@ -879,6 +879,31 @@ DWORD DOKANAPI DokanWaitForFileSystemClosed(_In_ DOKAN_HANDLE DokanInstance,
                                             _In_ DWORD dwMilliseconds);
 
 /**
+ * \brief Register callback for FileSystem unmount.
+ *
+ * \param DokanInstance The dokan mount context created by \ref DokanCreateFileSystem .
+ * \param WaitHandle Handle to wait handle registration. This handle needs to be closed by calling <a href="https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-unregisterwait">UnregisterWait</a>, <a href="https://learn.microsoft.com/en-us/windows/win32/sync/unregisterwait">UnregisterWaitEx</a> or \ref DokanUnregisterWaitForFileSystemClosed to unregister the callback .
+ * \param Callback Callback function to be called from a worker thread when file system is unmounted .
+ * \param Context A context parameter to send to callback function .
+ * \param dwMilliseconds The time-out interval, in milliseconds. See <a href="https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-registerwaitforsingleobject">RegisterWaitForSingleObject</a>.
+ * \return TRUE if successful, FALSE otherwise.
+ */
+BOOL DOKANAPI DokanRegisterWaitForFileSystemClosed(
+    _In_ DOKAN_HANDLE DokanInstance, _Out_ PHANDLE WaitHandle,
+    _In_ WAITORTIMERCALLBACKFUNC Callback, _In_ PVOID Context,
+    ULONG dwMilliseconds);
+
+/**
+ * \brief Unregister callback for FileSystem unmount.
+ *
+ * \param WaitHandle Handle returned as WaitHandle parameter in previous call to \ref DokanRegisterWaitForFileSystemClosed .
+ * \param WaitForCallbacks Indicates whether to wait for callbacks to complete before returning. Normally set to TRUE unless called from same thread as callback function.
+ * \return TRUE if successful, FALSE otherwise.
+ */
+BOOL DOKANAPI DokanUnregisterWaitForFileSystemClosed(_In_ HANDLE WaitHandle,
+                                                     BOOL WaitForCallbacks);
+
+/**
  * \brief Unmount the Dokan instance.
  * 
  * Unmount and wait until all resources of the \c DokanInstance are released.


### PR DESCRIPTION
Added two API functions `DokanRegisterWaitForFileSystemClosed` and `DokanUnregisterWaitForFileSystemClosed`, for registering and unregistering a callback to be called when the `DeviceClosedWaitHandle` is set. Makes it easier to register work to be done after dismount without letting a thread wait for it.

New feature.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-
-
-
