### PR TITLE
utils: fix a Y2038 bug by replacing `Int32x32To64` with multiplication

### DIFF
--- a/dokan_fuse/src/utils.cpp
+++ b/dokan_fuse/src/utils.cpp
@@ -78,9 +78,7 @@ std::string unixify(const std::string &str) {
 
 FILETIME unixTimeToFiletime(time_t t) {
   // Note that LONGLONG is a 64-bit value
-  LONGLONG ll;
-
-  ll = Int32x32To64(t, 10000000) + 116444736000000000LL;
+  LONGLONG ll = (t * 10000000LL) + 116444736000000000LL;
   FILETIME res;
   res.dwLowDateTime = static_cast<DWORD>(ll);
   res.dwHighDateTime = static_cast<DWORD>(ll >> 32);


### PR DESCRIPTION
### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the existing documentation
- [x] My changes generate no new warnings
- [ ] I have updated the change log (Add/Change/Fix)
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

`Int32x32To64` macro internally truncates the arguments to int32, while `time_t` is 64-bit on most/all modern platforms. Therefore, usage of this macro creates a Year 2038 bug.

I detailed this issue a while ago in a writeup, and spotted the same issue in this repository when updating the list of affected repositories:
<https://cookieplmonster.github.io/2022/02/17/year-2038-problem/>