### PR TITLE
Fix create return STATUS_SHARING_VIOLATION when breaking oplock

### DIFF
--- a/sys/dokan.h
+++ b/sys/dokan.h
@@ -806,6 +806,9 @@ typedef struct _REQUEST_CONTEXT {
 
   // Whether if we are the top-level IRP.
   BOOLEAN IsTopLevelIrp;
+
+  // the share access has been removed before DokanCheckOplock during DokanDispatchCleanup
+  BOOLEAN RemovedShareAccessBeforeCheckOplock;
 } REQUEST_CONTEXT, *PREQUEST_CONTEXT;
 
 // IRP list which has pending status


### PR DESCRIPTION
Fixes the issue Status: Open.
#1293

The reproduce method is provided in the issue. If one process opened the file with oplock granted, then another process try open the same file with read/write access, the open irp will block until previous handle being closed. The dokany now break the oplock without remove share access, which causes the afterward open return STATUS_SHARING_VIOLATION.